### PR TITLE
Docs: clarify implementation status and version domains; add Unreleased changelog and CLI scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Documentation
+
+- Clarify implementation status across Claude skills, Python CLI scaffolding, optional MCP enrichment, and the planned web UI control/review plane.
+- Document separate version domains for the plugin/content release, Python CLI package, individual skill frontmatter, and MCP server implementation.
+- Reconcile stale installation and security-policy references to older plugin/content release lines without creating a new numbered release.
+
+---
+
 ## [3.0] -- 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use Outrider to:
 - Produce finding cards, report-ready evidence, and recommended handoffs.
 - Stay inside an authorized, read-only recon boundary until the operator chooses the next step.
 
-The current bundle includes **11 Claude skills**, **90 capabilities**, **48 secret patterns**, **70 dorks**, **9 read-only validators**, **35 attack-path templates**, and an optional MCP server for live enrichment.
+The current bundle includes **11 implemented Claude skills**, **90 capabilities**, **48 secret patterns**, **70 dorks**, **9 read-only validator procedures**, **35 attack-path templates**, and an optional MCP server for live enrichment. The skills are the implemented capability layer; deterministic Python enforcement for scope, approvals, schemas, and evidence verification is planned but not yet implemented.
 
 ---
 
@@ -160,7 +160,7 @@ The optional MCP server adds live enrichment tools: crt.sh lookup, HudsonRock qu
 pip install -r ~/.local/share/outrider-recon/mcp-server/requirements.txt
 ```
 
-The `.mcp.json` config is included in the repo. All skills work without the MCP server; MCP just adds live data enrichment.
+The `.mcp.json` config is included in the repo. All skills work without the MCP server; MCP just adds live data enrichment. The current MCP server does **not** enforce scope by itself, so operators must apply the same authorization boundary before invoking live lookups.
 
 ### Manual Claude Code install
 
@@ -206,7 +206,8 @@ outrider-recon/
 ├── skills/offensive-osint/scripts/
 │   ├── h1_reference.py                 # HackerOne disclosed-reports reference agent, no API key
 │   └── secret_scan.py                  # stdlib-only secret scanner, JSONL output
-├── mcp-server/                         # optional live enrichment tools
+├── mcp-server/                         # optional live enrichment tools; no scope enforcement yet
+├── outrider/                           # Python CLI run-folder scaffolding
 ├── docs/                               # architecture, coverage, install, methods, reference docs
 ├── examples/                           # end-to-end walkthroughs and sample output
 ├── tests/smoke-test-prompts.md         # 43-prompt self-evaluation
@@ -232,18 +233,33 @@ outrider-recon/
 
 ---
 
+## Implementation status
+
+Outrider currently has four separate implementation domains:
+
+- **Implemented Claude skill layer:** the `skills/` directory is the primary capability layer. The skills provide methodology, routing, recon procedures, scoring guidance, report templates, and operator-facing safety rules.
+- **Python CLI scaffolding:** the `outrider` command currently initializes and inspects run folders. It creates files such as `scope.yaml`, `run.jsonl`, placeholder JSON sidecars, finding cards, technique cards, and report templates. It does not currently execute recon, validate schemas, enforce scope, record approvals, or verify evidence hashes.
+- **Optional MCP enrichment:** the MCP server provides live enrichment tools for crt.sh, HudsonRock, EPSS, Wayback CDX, and DNS lookups. It does not currently enforce scope at the tool boundary.
+- **Future web UI:** a web UI is intended as a shared control and review plane for scope, approvals, evidence, triage, and handoff. It is not implemented in this repository today.
+
 ## Roadmap
 
-Near-term productization work:
+Existing scaffolding:
 
-- `outrider` CLI harness for repeatable recon runs,
-- `scope.yaml` and run-folder state management,
-- machine-readable recon manifest,
-- finding cards and technique cards,
+- `outrider init` creates a run folder, `scope.yaml`, `run.jsonl`, placeholder JSON files, finding cards, technique cards, surface notes, and a report scaffold.
+- `outrider show` checks whether expected run-folder files exist.
+
+Planned deterministic controls and productization work:
+
+- machine-readable recon manifest and schema validation,
+- deterministic scope checks at CLI and MCP tool boundaries,
+- explicit approval records for higher-risk or post-discovery actions,
+- evidence artifact registration and hash verification,
 - first-class `outrider intel` for public disclosure intelligence,
 - report export for external recon / ASM / bug-bounty workflows,
 - handoff export for proxy-assisted testing, manual validation, ASM ticketing, and remediation workflows,
-- delta mode for continuous exposure monitoring.
+- delta mode for continuous exposure monitoring,
+- future web UI for shared control and review.
 
 The goal is not to turn Outrider into an exploitation framework. The goal is to make it the best Claude-native harness for **authorized external recon and attack-path prioritization**.
 
@@ -253,7 +269,7 @@ The goal is not to turn Outrider into an exploitation framework. The goal is to 
 
 These skills are intended for assets you **own** or have **written authorization to assess**: red-team rules of engagement, bug-bounty in-scope assets, ASM contracts, or internal security assessments.
 
-All skills include a soft scope check when you ask Claude to act against an unverified third-party target. They explicitly exclude active exploitation, post-exploitation, malware development, persistence, evasion, and other activities beyond OSINT-driven reconnaissance. See [`SECURITY.md`](SECURITY.md) for the full posture.
+All skills include a soft scope check when you ask Claude to act against an unverified third-party target. These controls are currently skill-level and operator-enforced; deterministic Python and MCP scope enforcement is planned but not currently implemented. The skills explicitly exclude active exploitation, post-exploitation, malware development, persistence, evasion, and other activities beyond OSINT-driven reconnaissance. See [`SECURITY.md`](SECURITY.md) for the full posture.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,16 +13,18 @@ This pipeline is intended for **external OSINT-driven reconnaissance against aut
 
 ## Responsible-use posture
 
-The pipeline includes a **soft scope-check** that triggers when a user asks Claude to act against an unverified third-party target:
+The current pipeline includes a **soft scope-check** at the Claude skill/operator layer that triggers when a user asks Claude to act against an unverified third-party target:
 
 > *"Quick scope check: is this a target you own or have written authorization to assess (e.g., a red-team engagement, in-scope bug-bounty asset, or your own infrastructure)?"*
 
 Pipeline content also includes:
 
 - An "Authorization & Legal Posture" section at the top of each SKILL.md.
-- Hard "Do NOT" rules covering destructive probes, credential-validator misuse, scope violations.
+- "Do NOT" rules covering destructive probes, credential-validator misuse, scope violations.
 - Detection-aware guidance encouraging back-off rather than evasion when active defenses are detected.
 - Validator discipline — only read-only credential verification; never destructive.
+
+These controls are currently primarily skill-level and operator-enforced. Deterministic Python/MCP scope enforcement, approval records, and tool-boundary checks are planned, but they are not currently implemented.
 
 ## Reporting a security issue with the skills themselves
 
@@ -51,16 +53,17 @@ If you used these skills during an authorized engagement and found a vulnerabili
 
 ## Supported versions
 
-| Version | Support status |
+| Version domain | Support status |
 |---|---|
-| 2.3.x (current) | ✅ Active |
-| 2.1.x | ⚠️ Bug fixes only |
-| 2.0.x | ❌ End of life |
-| 1.x | ❌ End of life |
+| Plugin/content v3.0 | ✅ Active |
+| Python CLI package | Early scaffolding; support follows the package metadata in `pyproject.toml` |
+| Individual skills | Supported according to each skill's YAML frontmatter and the active plugin/content release |
+| 2.x plugin/content lines | ⚠️ Superseded by v3.0 content |
+| 1.x plugin/content lines | ❌ End of life |
 
 ## Security best practices for users
 
-- Pin the pipeline version (`v2.3`) in any production deployment.
+- Pin the plugin/content release and Python package version separately in any production deployment.
 - Verify SHA-256 of skill files after cloning to confirm integrity.
 - Verify SHA-256 of any binary helper scripts before execution.
 - Don't commit your engagement-specific notes into a fork of this repo.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,20 @@
 # Architecture & Design Philosophy
 
+## Implementation status
+
+This document describes both implemented behavior and architectural design intent. The current implementation is intentionally split across separate domains:
+
+| Domain | Current status | Version source | Notes |
+|---|---|---|---|
+| Claude plugin/content release | Implemented as the skill bundle, plugin manifest, docs, examples, install scripts, and optional MCP companion listed in the changelog. | `CHANGELOG.md` and `.claude-plugin/plugin.json` | This release domain tracks the packaged Claude-facing content. |
+| Python CLI package | Implemented as run-folder scaffolding only. | `pyproject.toml` and `outrider/__init__.py` | The CLI currently initializes and shows run folders; it does not enforce scope, approvals, schemas, or evidence integrity. |
+| Individual skill frontmatter | Implemented per `skills/*/SKILL.md`. | Each skill's YAML `version:` field | Skill versions may differ from the plugin/content release and from the Python package version. |
+| MCP server | Implemented as optional live enrichment. | MCP server files and dependency metadata | The MCP server provides live lookup tools but does not currently enforce scope. |
+
+These version domains do not have to use the same number. A plugin/content release can advance independently from the Python CLI package, individual skill frontmatter, or MCP implementation.
+
+The asset graph, output schema, sidecar coordination, validator discipline, and approval/scope concepts below are the intended architecture. Some are implemented as Claude skill instructions and documentation today; deterministic Python/MCP enforcement is planned but not currently implemented unless explicitly described in code.
+
 ## The router + sub-skill split
 
 The skills are split into **methodology** ("how to think"), a **router** ("which sub-skill handles this"), and **9 focused sub-skills** ("what to reach for"). This reflects how practitioners actually work:
@@ -119,7 +134,7 @@ flowchart TD
     style Person fill:#ea580c,color:#fff
 ```
 
-29 asset types organized in 9 categories. 23 typed edges. Discipline: every discovery is a typed asset (never a free-floating string), with provenance tracked.
+29 asset types organized in 9 categories. 23 typed edges. Discipline: every discovery is a typed asset (never a free-floating string), with provenance tracked. This is the design model; the current Python CLI creates placeholder run-folder files and does not yet validate this graph.
 
 ## Output schema
 
@@ -145,7 +160,7 @@ Finding:
   remediation:  <action the asset owner can take>
 ```
 
-This shape is portable to any asset / findings store (ASM platforms, ticketing systems, custom DBs).
+This shape is portable to any asset / findings store (ASM platforms, ticketing systems, custom DBs). It is not yet enforced by a Python schema validator.
 
 ## Cross-module sidecar coordination
 
@@ -160,7 +175,7 @@ flowchart LR
     style A fill:#7c3aed,color:#fff
 ```
 
-Patterns documented in `analysis-and-reporting` §6.
+Patterns documented in `analysis-and-reporting` §6. Current sidecar coordination is skill/documentation-level guidance; the Python CLI does not yet validate sidecar schemas.
 
 ## Validator discipline
 
@@ -179,7 +194,7 @@ flowchart LR
     style A fill:#9a3412,color:#fff
 ```
 
-9 providers covered (Postman, AWS, GitHub, Slack, Anthropic, OpenAI, npm, Atlassian, DataDog). Hard rule: never create / delete / send. Tag every validation with detectability + `checked_at`.
+9 providers covered (Postman, AWS, GitHub, Slack, Anthropic, OpenAI, npm, Atlassian, DataDog). Hard rule: never create / delete / send. Tag every validation with detectability + `checked_at`. These validator rules are currently expressed in skills and operator procedures; deterministic enforcement is planned for future Python/MCP integration.
 
 ## Trigger frontmatter discipline
 
@@ -192,13 +207,22 @@ Each skill declares ~50–110 trigger phrases in YAML frontmatter. Triggers are:
 
 ## Versioning
 
-Semantic versioning. The `version:` field in YAML frontmatter is authoritative.
+Semantic versioning applies within each release domain rather than requiring all version numbers to match.
+
+| Version domain | Authoritative location | What it describes |
+|---|---|---|
+| Plugin/content release | `CHANGELOG.md` and `.claude-plugin/plugin.json` | The Claude-facing content bundle, documentation, examples, install scripts, and optional companion components. |
+| Python CLI package | `pyproject.toml` and `outrider/__init__.py` | The installable Python package and `outrider` console script. |
+| Individual skill versions | YAML frontmatter in each `skills/*/SKILL.md` | Skill-specific trigger/content changes. |
+| MCP server implementation | `mcp-server/` source and dependency files | Optional live enrichment server behavior and dependencies. |
+
+For individual skills:
 
 - **MAJOR** — section renumbering, breaking trigger changes, schema changes to Finding output.
 - **MINOR** — new sections, new techniques, expanded catalogs.
 - **PATCH** — typo fixes, link updates, severity-tier corrections.
 
-Current project release: v3.0. Individual skill versions in YAML frontmatter.
+The existing plugin/content release is v3.0. The Python CLI package and individual skill versions are separate domains and may use different numbers.
 
 ## Renumbering policy
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -144,9 +144,24 @@ All 11 skills together are ~3,000 lines. This fits comfortably in modern Claude 
 
 Edit `skills/<skill-name>/SKILL.md` directly. All files are plain Markdown. You can comment out sections you don't need or split them into multiple smaller skills.
 
-## Verifying skill version
+## Installing skills vs. the Python CLI
 
-All SKILL.md files declare `version:` in the YAML frontmatter. Current project release: v2.3. Individual skill versions in YAML frontmatter. Check via:
+The Claude skill/plugin bundle and the Python CLI package are separate installation concerns:
+
+- The one-click and manual Claude Code flows install the skill bundle into `~/.claude/skills/` so Claude can load the methodology and sub-skills.
+- The Python package exposes the `outrider` console script for run-folder scaffolding. The current CLI initializes and inspects run folders; it does not currently execute recon or enforce scope.
+- The optional MCP server is installed separately from `mcp-server/requirements.txt` and adds live enrichment tools. It does not currently enforce scope by itself.
+
+## Verifying versions
+
+Version numbers are tracked by domain rather than forced to match:
+
+- Plugin/content release: see `CHANGELOG.md` and `.claude-plugin/plugin.json`.
+- Python CLI package: see `pyproject.toml` and `outrider/__init__.py`.
+- Individual skills: see each SKILL.md YAML frontmatter.
+- MCP implementation: see `mcp-server/` source and dependencies.
+
+Check individual skill versions with:
 
 ```bash
 grep "^version:" skills/*/SKILL.md


### PR DESCRIPTION
### Motivation

- Clarify what is implemented today versus planned work across the Claude skills, Python CLI, MCP server, and future web UI. 
- Make versioning and release domains explicit so plugin/content, Python package, skills, and MCP can use separate version numbers. 
- Reconcile stale installation/security references that suggested deterministic CLI/MCP enforcement exists today. 

### Description

- Add an `Unreleased` section to `CHANGELOG.md` documenting documentation/versioning clarifications and reconciliation of old references. 
- Update `README.md` to mark the `skills/` layer as implemented, describe the `outrider` Python CLI as run-folder scaffolding, note MCP does not enforce scope, and add the `outrider/` scaffolding reference. 
- Update `SECURITY.md` and `docs/architecture.md` to explicitly describe separate version domains, current scope-enforcement status, and that deterministic Python/MCP controls are planned but not implemented. 
- Adjust `docs/installation.md` to separate skill/plugin installation from the Python CLI/MCP install flows and to show where to verify versions across domains. 

### Testing

- No automated code tests were run because this is a documentation and metadata-only change; no production code behavior was modified. 
- Existing CI (if configured) should be unaffected by these doc updates. 
- Basic verification consisted of updating the doc files and ensuring internal references (e.g., `CHANGELOG.md`, `.claude-plugin/plugin.json`, `pyproject.toml`, and skill frontmatter) are referenced consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5380484a6c833094da27de63061467)