### PR TITLE
test: add CLI coverage and pull-request CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
 on:
+  pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -93,3 +97,24 @@ jobs:
         with:
           scandir: .
           additional_files: install.sh uninstall.sh
+
+  python-cli-tests:
+    name: Python CLI tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.10'
+          - '3.11'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install local package
+        run: python -m pip install .
+      - name: Compile package and tests
+        run: python -m compileall outrider tests
+      - name: Run CLI unit tests
+        run: python -m unittest discover -s tests -p "test_*.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Documentation
 
+- Add automated CLI tests and pull-request CI coverage.
 - Clarify implementation status across Claude skills, Python CLI scaffolding, optional MCP enrichment, and the planned web UI control/review plane.
 - Document separate version domains for the plugin/content release, Python CLI package, individual skill frontmatter, and MCP server implementation.
 - Reconcile stale installation and security-policy references to older plugin/content release lines without creating a new numbered release.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,135 @@
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from outrider import cli
+
+
+class NormalizeRunNameTests(unittest.TestCase):
+    def test_removes_http_scheme(self):
+        self.assertEqual(cli.normalize_run_name("http://example.com"), "example.com")
+
+    def test_removes_https_scheme(self):
+        self.assertEqual(cli.normalize_run_name("https://example.com"), "example.com")
+
+    def test_removes_trailing_slashes(self):
+        self.assertEqual(cli.normalize_run_name("https://example.com///"), "example.com")
+
+    def test_preserves_normal_domain_or_run_name(self):
+        self.assertEqual(cli.normalize_run_name("example.com"), "example.com")
+        self.assertEqual(cli.normalize_run_name("acme-q3-recon"), "acme-q3-recon")
+
+
+class CliCommandTests(unittest.TestCase):
+    expected_json_sidecars = set(cli.DEFAULT_FILES)
+    expected_markdown_templates = {
+        "findings.md",
+        "technique_cards.md",
+        "surface.md",
+        "report.md",
+    }
+    expected_files = {
+        "scope.yaml",
+        "run.jsonl",
+        *expected_json_sidecars,
+        *expected_markdown_templates,
+    }
+
+    def run_cli(self, *argv):
+        stdout = StringIO()
+        with patch.object(sys, "argv", ["outrider", *argv]), redirect_stdout(stdout):
+            status = cli.main()
+        return status, stdout.getvalue()
+
+    def test_init_creates_expected_run_files_and_preserves_edits(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, output = self.run_cli(
+                "init",
+                "https://example.com/",
+                "--scope",
+                "example.com",
+                "--scope",
+                "*.example.com",
+                "--exclude",
+                "admin.example.com",
+                "--exclude",
+                "legacy.example.com",
+                "--output-dir",
+                tmpdir,
+            )
+
+            self.assertEqual(status, 0)
+            run_dir = Path(tmpdir) / "example.com"
+            self.assertTrue(run_dir.is_dir())
+            self.assertIn(f"Initialized Outrider run: {run_dir}", output)
+
+            for filename in self.expected_files:
+                self.assertTrue((run_dir / filename).exists(), f"missing {filename}")
+
+            scope_yaml = (run_dir / "scope.yaml").read_text(encoding="utf-8")
+            self.assertIn("target: example.com", scope_yaml)
+            self.assertIn("  - example.com", scope_yaml)
+            self.assertIn("  - *.example.com", scope_yaml)
+            self.assertIn("  - admin.example.com", scope_yaml)
+            self.assertIn("  - legacy.example.com", scope_yaml)
+
+            events = [
+                json.loads(line)
+                for line in (run_dir / "run.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["event"], "run_initialized")
+            self.assertEqual(events[0]["target"], "example.com")
+            self.assertEqual(events[0]["run_dir"], str(run_dir))
+            self.assertIn("created_at", events[0])
+
+            edited_report = "# Operator edited report\n\nKeep this content.\n"
+            (run_dir / "report.md").write_text(edited_report, encoding="utf-8")
+
+            rerun_status, rerun_output = self.run_cli(
+                "init",
+                "example.com",
+                "--output-dir",
+                tmpdir,
+            )
+
+            self.assertEqual(rerun_status, 0)
+            self.assertIn("No files created; run folder already existed.", rerun_output)
+            self.assertEqual((run_dir / "report.md").read_text(encoding="utf-8"), edited_report)
+            rerun_events = (run_dir / "run.jsonl").read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(rerun_events), 2)
+
+    def test_show_returns_failure_for_missing_run_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_dir = Path(tmpdir) / "missing"
+            status, output = self.run_cli("show", str(missing_dir))
+
+            self.assertEqual(status, 1)
+            self.assertIn(f"Run folder not found: {missing_dir}", output)
+
+    def test_show_reports_present_and_missing_expected_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init_status, _ = self.run_cli("init", "example.com", "--output-dir", tmpdir)
+            self.assertEqual(init_status, 0)
+            run_dir = Path(tmpdir) / "example.com"
+
+            show_status, show_output = self.run_cli("show", str(run_dir))
+            self.assertEqual(show_status, 0)
+            self.assertIn(f"Outrider run: {run_dir}", show_output)
+            for filename in self.expected_files:
+                self.assertIn(f"[ok] {filename}", show_output)
+
+            (run_dir / "assets.json").unlink()
+            missing_status, missing_output = self.run_cli("show", str(run_dir))
+            self.assertEqual(missing_status, 0)
+            self.assertIn("[missing] assets.json", missing_output)
+            self.assertIn("[ok] scope.yaml", missing_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Add automated unit coverage for the Outrider CLI and enable CI on pull requests and main to detect regressions early.
- Preserve the existing CLI behaviors for `normalize_run_name`, `init` (creating run folder, `scope.yaml`, `run.jsonl`, JSON sidecars, markdown templates, and emitting a `run_initialized` JSONL event), and `show` (reporting expected files and appropriate exit codes).

### Description

- Add `tests/test_cli.py` containing `unittest` cases for `normalize_run_name`, `init` (file creation, JSONL event, scope content, and preservation of operator edits), and `show` (missing run, present files, and missing-file reporting).
- Update `.github/workflows/lint.yml` to trigger on `pull_request`, `push` to `main`, and `workflow_dispatch`, and add a `python-cli-tests` job that runs on Python 3.10 and 3.11, installs the local package, compiles `outrider` and `tests`, and runs the unit tests with `python -m unittest discover -s tests -p "test_*.py"`.
- Add a concise Unreleased entry in `CHANGELOG.md` noting the addition of automated CLI tests and pull-request CI coverage.
- No production dependencies were added and no runtime changes were made to `outrider/cli.py`.

### Testing

- Ran `python -m unittest discover -s tests -p "test_*.py"` which completed successfully with 7 tests passing.
- Ran `python -m compileall outrider tests` which completed successfully.
- Ran `git diff --check` and `git status --short`; the only changes staged and committed are `.github/workflows/lint.yml`, `CHANGELOG.md`, and `tests/test_cli.py` and the final commit SHA is `fa5a28dd0875ddc48845ae9587dc6528c7624fe4`.
- Note: an attempt to fetch `origin/main` could not run in this environment because the `origin` remote was not available, so changes were applied to the repository state at HEAD `c77237643d5c1a213331e56c83ee3b2ce3abf30d`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5391d270408330bdeca8eb3df7f06d)