### PR TITLE
feat: add deterministic scope validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add deterministic scope-file validation with exact-domain, wildcard-subdomain, exact-IP, and CIDR matching.
+- Add out-of-scope precedence, default-deny scope decisions, and the offline `outrider scope-check` CLI command.
+
 ### Documentation
 
 - Add automated CLI tests and pull-request CI coverage.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,25 @@ curl -fsSL https://raw.githubusercontent.com/Ap6pack/outrider-recon/main/install
 
 This clones the repo, symlinks all 11 skills into `~/.claude/skills/`, and prepares Claude Code to auto-load the relevant skills. Re-run the same command to update.
 
+### Offline scope checks
+
+Run folders contain a `scope.yaml` file that can be evaluated without DNS resolution, hostname resolution, or network activity:
+
+```bash
+outrider scope-check runs/example.com api.example.com
+outrider scope-check runs/example.com https://api.example.com/path --json
+```
+
+Scope rules are deterministic:
+
+- exact domains such as `example.com` match only that exact domain and do not include subdomains;
+- wildcard subdomains such as `*.example.com` match `api.example.com` and deeper subdomains, but do not include the apex `example.com`;
+- exact IPv4/IPv6 addresses and IPv4/IPv6 CIDR networks are supported;
+- `out_of_scope` exclusions override `in_scope` inclusions;
+- unmatched candidates are denied by default;
+- domain rules never authorize the IP addresses that a domain may resolve to because no DNS resolution occurs;
+- `outrider scope-check` only parses local scope configuration and candidate values, and performs no network activity.
+
 ### MCP Server (optional)
 
 The optional MCP server adds live enrichment tools: crt.sh lookup, HudsonRock query, EPSS scoring, Wayback CDX, and DNS records.
@@ -238,7 +257,7 @@ outrider-recon/
 Outrider currently has four separate implementation domains:
 
 - **Implemented Claude skill layer:** the `skills/` directory is the primary capability layer. The skills provide methodology, routing, recon procedures, scoring guidance, report templates, and operator-facing safety rules.
-- **Python CLI scaffolding:** the `outrider` command currently initializes and inspects run folders. It creates files such as `scope.yaml`, `run.jsonl`, placeholder JSON sidecars, finding cards, technique cards, and report templates. It does not currently execute recon, validate schemas, enforce scope, record approvals, or verify evidence hashes.
+- **Python CLI scaffolding:** the `outrider` command currently initializes and inspects run folders. It creates files such as `scope.yaml`, `run.jsonl`, placeholder JSON sidecars, finding cards, technique cards, and report templates. It does not execute recon, record approvals, or verify evidence hashes; it now includes offline deterministic scope-file validation and `outrider scope-check`.
 - **Optional MCP enrichment:** the MCP server provides live enrichment tools for crt.sh, HudsonRock, EPSS, Wayback CDX, and DNS lookups. It does not currently enforce scope at the tool boundary.
 - **Future web UI:** a web UI is intended as a shared control and review plane for scope, approvals, evidence, triage, and handoff. It is not implemented in this repository today.
 
@@ -269,7 +288,7 @@ The goal is not to turn Outrider into an exploitation framework. The goal is to 
 
 These skills are intended for assets you **own** or have **written authorization to assess**: red-team rules of engagement, bug-bounty in-scope assets, ASM contracts, or internal security assessments.
 
-All skills include a soft scope check when you ask Claude to act against an unverified third-party target. These controls are currently skill-level and operator-enforced; deterministic Python and MCP scope enforcement is planned but not currently implemented. The skills explicitly exclude active exploitation, post-exploitation, malware development, persistence, evasion, and other activities beyond OSINT-driven reconnaissance. See [`SECURITY.md`](SECURITY.md) for the full posture.
+All skills include a soft scope check when you ask Claude to act against an unverified third-party target. These controls are currently skill-level and operator-enforced; deterministic Python scope checks are available through `outrider scope-check`, while MCP scope enforcement is planned but not currently implemented. The skills explicitly exclude active exploitation, post-exploitation, malware development, persistence, evasion, and other activities beyond OSINT-driven reconnaissance. See [`SECURITY.md`](SECURITY.md) for the full posture.
 
 ---
 

--- a/outrider/cli.py
+++ b/outrider/cli.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from outrider.scope import evaluate_scope_path
+
 
 DEFAULT_FILES = {
     "assets.json": {"assets": [], "notes": "Discovered assets will be stored here."},
@@ -37,7 +39,11 @@ def append_jsonl(path: Path, event: dict) -> None:
 
 def render_scope_yaml(target: str, scopes: Iterable[str], exclusions: Iterable[str]) -> str:
     scope_lines = "\n".join(f"  - {item}" for item in scopes) or "  - TODO"
-    exclusion_lines = "\n".join(f"  - {item}" for item in exclusions) or "  - none"
+    exclusion_items = list(exclusions)
+    if exclusion_items:
+        exclusion_block = "out_of_scope:\n" + "\n".join(f"  - {item}" for item in exclusion_items)
+    else:
+        exclusion_block = "out_of_scope: []"
     return f"""target: {target}
 created_at: {utc_now()}
 engagement_type: authorized_external_recon
@@ -47,8 +53,7 @@ boundary:
   - no_destructive_validation_without_written_authorization
 in_scope:
 {scope_lines}
-out_of_scope:
-{exclusion_lines}
+{exclusion_block}
 traffic_tagging:
   user_agent: TODO
   source_ip: TODO
@@ -235,6 +240,23 @@ def show_run(args: argparse.Namespace) -> int:
     return 0
 
 
+def scope_check(args: argparse.Namespace) -> int:
+    decision = evaluate_scope_path(args.run_dir, args.candidate)
+    if args.json:
+        print(json.dumps(decision.to_dict(), sort_keys=True))
+    else:
+        print(decision.decision.upper())
+        print(f"Normalized candidate: {decision.normalized_candidate or 'n/a'}")
+        print(f"Matched rule: {decision.matched_rule or 'none'}")
+        print(f"Matched rule source: {decision.matched_rule_source}")
+        print(f"Reason: {decision.reason}")
+    if decision.decision == "allow":
+        return 0
+    if decision.decision == "deny":
+        return 1
+    return 2
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="outrider", description="Outrider Recon CLI harness for run-folder creation and evidence-backed handoff.")
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -249,6 +271,12 @@ def build_parser() -> argparse.ArgumentParser:
     show_parser = subcommands.add_parser("show", help="Show expected files for a run folder.")
     show_parser.add_argument("run_dir", help="Run folder path, for example runs/acme.example.")
     show_parser.set_defaults(func=show_run)
+
+    scope_parser = subcommands.add_parser("scope-check", help="Evaluate a candidate against a run folder's scope.yaml.")
+    scope_parser.add_argument("run_dir", help="Run folder path containing scope.yaml.")
+    scope_parser.add_argument("candidate", help="Domain, IP address, or URL to evaluate.")
+    scope_parser.add_argument("--json", action="store_true", help="Emit the structured scope decision as JSON.")
+    scope_parser.set_defaults(func=scope_check)
 
     return parser
 

--- a/outrider/scope.py
+++ b/outrider/scope.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
+from pathlib import Path
+import re
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+import yaml
+
+CandidateType = Literal['domain', 'ip']
+DecisionValue = Literal['allow', 'deny', 'error']
+RuleSource = Literal['in_scope', 'out_of_scope', 'none']
+RuleType = Literal['domain', 'wildcard', 'ip', 'cidr']
+
+class ScopeValidationError(ValueError):
+    pass
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_mapping(
+    loader: _UniqueKeySafeLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    loader.flatten_mapping(node)
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise ScopeValidationError(f"duplicate YAML key: {key}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping,
+)
+
+
+@dataclass(frozen=True)
+class ScopeRule:
+    original: str
+    kind: RuleType
+    value: str | IPv4Address | IPv6Address | IPv4Network | IPv6Network
+
+
+@dataclass(frozen=True)
+class ScopeConfig:
+    path: Path
+    in_scope: tuple[ScopeRule, ...]
+    out_of_scope: tuple[ScopeRule, ...]
+
+
+@dataclass(frozen=True)
+class ScopeDecision:
+    original_candidate: str
+    normalized_candidate: str | None
+    candidate_type: CandidateType | None
+    decision: DecisionValue
+    matched_rule: str | None
+    matched_rule_source: RuleSource
+    reason: str
+
+    def to_dict(self) -> dict[str, str | None]:
+        return asdict(self)
+
+
+_DOMAIN_LABEL = re.compile(r'^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$')
+
+
+def load_scope(run_dir: str | Path) -> ScopeConfig:
+    path = Path(run_dir) / 'scope.yaml'
+    if not path.exists():
+        raise ScopeValidationError(f"scope.yaml not found: {path}")
+    try:
+        data = yaml.load(path.read_text(encoding='utf-8'), Loader=_UniqueKeySafeLoader)
+    except ScopeValidationError:
+        raise
+    except yaml.YAMLError as exc:
+        raise ScopeValidationError(f"malformed YAML in {path}: {exc}") from exc
+    except OSError as exc:
+        raise ScopeValidationError(f"could not read {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ScopeValidationError('scope.yaml must contain a top-level mapping')
+    if 'in_scope' not in data:
+        raise ScopeValidationError('scope.yaml must define in_scope')
+    raw_in = data['in_scope']
+    if not isinstance(raw_in, list):
+        raise ScopeValidationError('in_scope must be a list of strings')
+    if not raw_in:
+        raise ScopeValidationError('in_scope must not be empty')
+    raw_out = data.get('out_of_scope', [])
+    if not isinstance(raw_out, list):
+        raise ScopeValidationError('out_of_scope must be a list of strings when present')
+    if raw_out == ['none']:
+        raw_out = []
+    in_rules = tuple(_parse_rule(rule, 'in_scope') for rule in raw_in)
+    out_rules = tuple(_parse_rule(rule, 'out_of_scope') for rule in raw_out)
+    return ScopeConfig(path=path, in_scope=in_rules, out_of_scope=out_rules)
+
+
+def evaluate_scope(config: ScopeConfig, candidate: str) -> ScopeDecision:
+    try:
+        normalized, candidate_type, candidate_value = _normalize_candidate(candidate)
+    except ScopeValidationError as exc:
+        return ScopeDecision(candidate, None, None, 'error', None, 'none', str(exc))
+    for rule in config.out_of_scope:
+        if _rule_matches(rule, candidate_type, candidate_value):
+            return ScopeDecision(
+                candidate,
+                normalized,
+                candidate_type,
+                'deny',
+                rule.original,
+                'out_of_scope',
+                'candidate matches out_of_scope rule',
+            )
+    for rule in config.in_scope:
+        if _rule_matches(rule, candidate_type, candidate_value):
+            return ScopeDecision(
+                candidate,
+                normalized,
+                candidate_type,
+                'allow',
+                rule.original,
+                'in_scope',
+                'candidate matches in_scope rule',
+            )
+    return ScopeDecision(
+        candidate,
+        normalized,
+        candidate_type,
+        'deny',
+        None,
+        'none',
+        'candidate did not match any in_scope rule',
+    )
+
+
+def evaluate_scope_path(run_dir: str | Path, candidate: str) -> ScopeDecision:
+    try:
+        config = load_scope(run_dir)
+    except ScopeValidationError as exc:
+        return ScopeDecision(candidate, None, None, 'error', None, 'none', str(exc))
+    return evaluate_scope(config, candidate)
+
+
+def _parse_rule(rule: Any, source: str) -> ScopeRule:
+    if not isinstance(rule, str):
+        raise ScopeValidationError(f'{source} rules must be strings')
+    original = rule
+    text = rule.strip().lower()
+    if not text:
+        raise ScopeValidationError(f'{source} contains an empty rule')
+    if '://' in text or '?' in text or '#' in text or '@' in text:
+        raise ScopeValidationError(
+            f'invalid {source} rule {original!r}: scope rules must be domains, '
+            'wildcard domains, IPs, or CIDRs, not URLs or paths'
+        )
+    if text == '*':
+        raise ScopeValidationError(f'invalid {source} rule {original!r}: bare wildcard is not allowed')
+    try:
+        if '/' in text:
+            return ScopeRule(original, 'cidr', ip_network(text, strict=True))
+    except ValueError as exc:
+        if '/' in text:
+            raise ScopeValidationError(f'invalid {source} CIDR rule {original!r}: {exc}') from exc
+    try:
+        return ScopeRule(original, 'ip', ip_address(text))
+    except ValueError:
+        if _looks_like_ip_literal(text):
+            raise ScopeValidationError(f'invalid {source} IP rule {original!r}')
+    if '*' in text:
+        if not text.startswith('*.') or text.count('*') != 1:
+            raise ScopeValidationError(
+                f'invalid {source} wildcard rule {original!r}: '
+                'wildcard must be the complete leftmost label'
+            )
+        apex = text[2:]
+        _validate_domain(apex, original, source)
+        return ScopeRule(original, 'wildcard', apex)
+    if '/' in text or ':' in text:
+        raise ScopeValidationError(
+            f'invalid {source} rule {original!r}: '
+            'domain rules must not contain paths, ports, or credentials'
+        )
+    _validate_domain(text, original, source)
+    return ScopeRule(original, 'domain', text)
+
+
+def _normalize_candidate(
+    candidate: str,
+) -> tuple[str, CandidateType, str | IPv4Address | IPv6Address]:
+    if not isinstance(candidate, str):
+        raise ScopeValidationError('candidate must be a string')
+    text = candidate.strip()
+    if not text:
+        raise ScopeValidationError('candidate must not be empty')
+    if '://' in text:
+        parsed = urlsplit(text)
+        if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+            raise ScopeValidationError('candidate URL is malformed')
+        if parsed.username is not None or parsed.password is not None:
+            raise ScopeValidationError('candidate URL must not contain embedded credentials')
+        host = parsed.hostname
+        return _normalize_host(host)
+    if any(ch in text for ch in '/?#@'):
+        raise ScopeValidationError('candidate must be a domain, IP address, or URL')
+    if ':' in text and not _can_be_ip(text):
+        raise ScopeValidationError(
+            'candidate contains a port or malformed IPv6 address; '
+            'use a valid URL for host:port values'
+        )
+    return _normalize_host(text)
+
+
+def _normalize_host(
+    host: str,
+) -> tuple[str, CandidateType, str | IPv4Address | IPv6Address]:
+    host = host.strip().lower()
+    if host.endswith('.'):
+        host = host[:-1]
+    if not host:
+        raise ScopeValidationError('candidate hostname is empty')
+    try:
+        ip = ip_address(host)
+        return str(ip), 'ip', ip
+    except ValueError:
+        if _looks_like_ip_literal(host):
+            raise ScopeValidationError('candidate IP address is malformed')
+    _validate_domain(host, host, 'candidate')
+    return host, 'domain', host
+
+
+def _validate_domain(domain: str, original: str, source: str) -> None:
+    if len(domain) > 253:
+        raise ScopeValidationError(f'invalid {source} domain {original!r}: domain is too long')
+    if domain.startswith('.') or domain.endswith('.') or '..' in domain:
+        raise ScopeValidationError(f'invalid {source} domain {original!r}')
+    labels = domain.split('.')
+    if len(labels) < 2:
+        raise ScopeValidationError(f'invalid {source} domain {original!r}: expected at least two labels')
+    for label in labels:
+        if not _DOMAIN_LABEL.fullmatch(label):
+            raise ScopeValidationError(f'invalid {source} domain {original!r}')
+
+
+def _rule_matches(
+    rule: ScopeRule,
+    candidate_type: CandidateType,
+    candidate_value: str | IPv4Address | IPv6Address,
+) -> bool:
+    if candidate_type == 'ip':
+        if rule.kind == 'ip':
+            return candidate_value == rule.value
+        if rule.kind == 'cidr':
+            return candidate_value in rule.value  # type: ignore[operator]
+        return False
+    if rule.kind == 'domain':
+        return candidate_value == rule.value
+    if rule.kind == 'wildcard':
+        suffix = '.' + str(rule.value)
+        return (
+            isinstance(candidate_value, str)
+            and candidate_value.endswith(suffix)
+            and candidate_value != rule.value
+        )
+    return False
+
+
+def _looks_like_ip_literal(text: str) -> bool:
+    return ':' in text or bool(re.fullmatch(r'[0-9.]+', text))
+
+
+def _can_be_ip(text: str) -> bool:
+    try:
+        ip_address(text)
+        return True
+    except ValueError:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ license = { text = "MIT" }
 authors = [
   { name = "Ap6pack" }
 ]
-dependencies = []
+dependencies = [
+  "PyYAML>=6",
+]
 
 [project.scripts]
 outrider = "outrider.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,53 @@ class CliCommandTests(unittest.TestCase):
             rerun_events = (run_dir / "run.jsonl").read_text(encoding="utf-8").splitlines()
             self.assertEqual(len(rerun_events), 2)
 
+    def test_init_uses_empty_out_of_scope_list_and_preserves_scope(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, _ = self.run_cli("init", "example.com", "--output-dir", tmpdir)
+            self.assertEqual(status, 0)
+            run_dir = Path(tmpdir) / "example.com"
+            scope_path = run_dir / "scope.yaml"
+            scope_yaml = scope_path.read_text(encoding="utf-8")
+            self.assertIn("out_of_scope: []", scope_yaml)
+            edited_scope = "in_scope:\n  - edited.example.com\nout_of_scope: []\n"
+            scope_path.write_text(edited_scope, encoding="utf-8")
+            rerun_status, _ = self.run_cli("init", "example.com", "--output-dir", tmpdir)
+            self.assertEqual(rerun_status, 0)
+            self.assertEqual(scope_path.read_text(encoding="utf-8"), edited_scope)
+
+    def test_scope_check_cli_allow_deny_error_and_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = Path(tmpdir) / "run"
+            run_dir.mkdir()
+            (run_dir / "scope.yaml").write_text(
+                "in_scope:\n  - example.com\n  - '*.example.com'\nout_of_scope:\n  - blocked.example.com\n",
+                encoding="utf-8",
+            )
+            allow_status, allow_output = self.run_cli("scope-check", str(run_dir), "example.com")
+            self.assertEqual(allow_status, 0)
+            self.assertIn("ALLOW", allow_output)
+            deny_status, deny_output = self.run_cli("scope-check", str(run_dir), "other.example.net")
+            self.assertEqual(deny_status, 1)
+            self.assertIn("DENY", deny_output)
+            excluded_status, excluded_output = self.run_cli("scope-check", str(run_dir), "blocked.example.com")
+            self.assertEqual(excluded_status, 1)
+            self.assertIn("DENY", excluded_output)
+            json_status, json_output = self.run_cli("scope-check", str(run_dir), "https://api.example.com/path", "--json")
+            self.assertEqual(json_status, 0)
+            payload = json.loads(json_output)
+            self.assertEqual(payload["decision"], "allow")
+            self.assertEqual(payload["normalized_candidate"], "api.example.com")
+            self.assertEqual(payload["matched_rule"], "*.example.com")
+            self.assertEqual(payload["matched_rule_source"], "in_scope")
+            self.assertIn("reason", payload)
+            missing_status, missing_output = self.run_cli("scope-check", str(Path(tmpdir) / "missing"), "example.com")
+            self.assertEqual(missing_status, 2)
+            self.assertIn("ERROR", missing_output)
+            (run_dir / "scope.yaml").write_text("in_scope: []\n", encoding="utf-8")
+            invalid_status, invalid_output = self.run_cli("scope-check", str(run_dir), "example.com")
+            self.assertEqual(invalid_status, 2)
+            self.assertIn("ERROR", invalid_output)
+
     def test_show_returns_failure_for_missing_run_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             missing_dir = Path(tmpdir) / "missing"

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,165 @@
+import socket
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from outrider.scope import ScopeValidationError, evaluate_scope, load_scope
+
+
+def write_scope(base, text):
+    path = Path(base)
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "scope.yaml").write_text(text, encoding="utf-8")
+    return path
+
+
+class ScopeLoadingTests(unittest.TestCase):
+    def test_valid_generated_scope_yaml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(
+                tmp,
+                "target: example.com\nin_scope:\n  - example.com\nout_of_scope: []\nnotes:\n  - ignored\n",
+            )
+            config = load_scope(run)
+            self.assertEqual(len(config.in_scope), 1)
+            self.assertEqual(config.out_of_scope, ())
+
+    def test_valid_manual_scope_yaml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(
+                tmp,
+                "in_scope: ['*.example.com', '192.0.2.0/24', '2001:db8::/32']\n"
+                "out_of_scope: ['admin.example.com']\nboundary: ignored\n",
+            )
+            config = load_scope(run)
+            self.assertEqual(len(config.in_scope), 3)
+            self.assertEqual(len(config.out_of_scope), 1)
+
+    def test_missing_scope_yaml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ScopeValidationError, "not found"):
+                load_scope(tmp)
+
+    def test_malformed_yaml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(tmp, "in_scope: [example.com\n")
+            with self.assertRaisesRegex(ScopeValidationError, "malformed YAML"):
+                load_scope(run)
+
+    def test_duplicate_keys(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(tmp, "in_scope:\n  - example.com\nin_scope:\n  - other.example\n")
+            with self.assertRaisesRegex(ScopeValidationError, "duplicate YAML key"):
+                load_scope(run)
+
+    def test_missing_and_empty_in_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(tmp, "out_of_scope: []\n")
+            with self.assertRaisesRegex(ScopeValidationError, "define in_scope"):
+                load_scope(run)
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(tmp, "in_scope: []\n")
+            with self.assertRaisesRegex(ScopeValidationError, "must not be empty"):
+                load_scope(run)
+
+    def test_wrong_field_types_and_empty_rule(self):
+        cases = [
+            ("in_scope: example.com\n", "in_scope must be a list"),
+            ("in_scope: [example.com]\nout_of_scope: none\n", "out_of_scope must be a list"),
+            ("in_scope: [123]\n", "rules must be strings"),
+            ("in_scope: ['']\n", "empty rule"),
+        ]
+        for text, message in cases:
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as tmp:
+                run = write_scope(tmp, text)
+                with self.assertRaisesRegex(ScopeValidationError, message):
+                    load_scope(run)
+
+    def test_invalid_rules(self):
+        bad_rules = [
+            "*",
+            "api.*.example.com",
+            "exa_mple.com",
+            "https://example.com",
+            "example.com/path",
+            "example.com:443",
+            "192.0.2.999",
+            "192.0.2.1/24",
+        ]
+        for rule in bad_rules:
+            with self.subTest(rule=rule), tempfile.TemporaryDirectory() as tmp:
+                run = write_scope(tmp, f"in_scope:\n  - {rule}\n")
+                with self.assertRaises(ScopeValidationError):
+                    load_scope(run)
+
+    def test_legacy_none_and_new_empty_out_of_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(tmp, "in_scope:\n  - example.com\nout_of_scope:\n  - none\n")
+            self.assertEqual(load_scope(run).out_of_scope, ())
+        with tempfile.TemporaryDirectory() as tmp:
+            run = write_scope(tmp, "in_scope:\n  - example.com\nout_of_scope: []\n")
+            self.assertEqual(load_scope(run).out_of_scope, ())
+
+
+class ScopeDecisionTests(unittest.TestCase):
+    def config(self, text):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        run = write_scope(tmp.name, text)
+        return load_scope(run)
+
+    def test_domain_behavior(self):
+        cfg = self.config("in_scope:\n  - example.com\n  - '*.example.com'\nout_of_scope: []\n")
+        self.assertEqual(evaluate_scope(cfg, "example.com").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "api.example.com").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "EXAMPLE.COM.").normalized_candidate, "example.com")
+        apex_only = self.config("in_scope:\n  - example.com\n")
+        self.assertEqual(evaluate_scope(apex_only, "api.example.com").decision, "deny")
+        wildcard_only = self.config("in_scope:\n  - '*.example.com'\n")
+        self.assertEqual(evaluate_scope(wildcard_only, "api.example.com").decision, "allow")
+        self.assertEqual(evaluate_scope(wildcard_only, "deeper.example.api.example.com").decision, "allow")
+        self.assertEqual(evaluate_scope(wildcard_only, "example.com").decision, "deny")
+        self.assertEqual(evaluate_scope(wildcard_only, "unrelated.example.net").decision, "deny")
+
+    def test_exclusion_behavior(self):
+        cfg = self.config(
+            "in_scope:\n  - example.com\n  - '*.example.com'\n"
+            "out_of_scope:\n  - example.com\n  - api.example.com\n  - '*.blocked.example.com'\n"
+        )
+        self.assertEqual(evaluate_scope(cfg, "example.com").decision, "deny")
+        self.assertEqual(evaluate_scope(cfg, "api.example.com").matched_rule_source, "out_of_scope")
+        self.assertEqual(evaluate_scope(cfg, "x.blocked.example.com").decision, "deny")
+        self.assertEqual(evaluate_scope(cfg, "other.net").decision, "deny")
+
+    def test_ip_behavior(self):
+        cfg = self.config(
+            "in_scope:\n  - 192.0.2.10\n  - 198.51.100.0/24\n"
+            "  - 2001:db8::1\n  - 2001:db8:abcd::/48\n"
+            "out_of_scope:\n  - 198.51.100.7\n"
+        )
+        self.assertEqual(evaluate_scope(cfg, "192.0.2.10").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "192.0.2.11").decision, "deny")
+        self.assertEqual(evaluate_scope(cfg, "198.51.100.8").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "198.51.101.8").decision, "deny")
+        self.assertEqual(evaluate_scope(cfg, "2001:db8::1").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "2001:db8:abcd::5").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "2001:db8:ffff::5").decision, "deny")
+        self.assertEqual(evaluate_scope(cfg, "198.51.100.7").matched_rule_source, "out_of_scope")
+
+    def test_url_behavior_and_no_network_request(self):
+        cfg = self.config("in_scope:\n  - api.example.com\n  - 192.0.2.0/24\n")
+        with patch.object(socket, "getaddrinfo", side_effect=AssertionError("network")):
+            self.assertEqual(
+                evaluate_scope(cfg, "https://api.example.com/path?q=1#frag").decision,
+                "allow",
+            )
+            self.assertEqual(evaluate_scope(cfg, "https://192.0.2.3/path").decision, "allow")
+        self.assertEqual(evaluate_scope(cfg, "https://user:pass@api.example.com/").decision, "error")
+        self.assertEqual(evaluate_scope(cfg, "https:///missing-host").decision, "error")
+        self.assertEqual(evaluate_scope(cfg, "api.example.com/path").decision, "error")
+        self.assertEqual(evaluate_scope(cfg, "api.example.com:443").decision, "error")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Add a deterministic, offline safety control so Outrider can parse and validate a run-folder `scope.yaml` and decide whether a domain, host, or IP is authorized without performing network activity. 
- Provide a reusable Python interface and a CLI entry (`outrider scope-check`) so future CLI, MCP, and control-plane code can rely on the same validation and decision semantics.

### Description

- Added `outrider/scope.py` implementing `load_scope(...)`, `evaluate_scope(...)`, `evaluate_scope_path(...)`, typed structures (`ScopeConfig`, `ScopeDecision`, `ScopeValidationError`), safe YAML loading that rejects duplicate keys, and deterministic rule parsing for exact domains, wildcard subdomains, IP literals, and CIDRs. 
- Implemented robust candidate normalization and validation (domains, IPv4/IPv6, and URL host extraction), deterministic decision order (error → out_of_scope deny → in_scope allow → deny), clear human-readable reasons, and no DNS or network calls. 
- Extended `outrider/cli.py` with `scope-check RUN_DIR CANDIDATE [--json]` and updated `render_scope_yaml` to emit `out_of_scope: []` for empty exclusions while preserving existing files on `init` reruns. 
- Added unit tests `tests/test_scope.py` (comprehensive scope parsing/decision coverage) and extended `tests/test_cli.py`, and added `PyYAML>=6` to `pyproject.toml` to use `yaml.SafeLoader` with a duplicate-key check.

### Testing

- Ran `python -m unittest discover -s tests -p "test_*.py"` which passed (22 tests run, all OK). 
- Ran `python -m compileall outrider tests` which completed without errors. 
- Ran `python -m pip check` which reported no broken requirements. 
- Ran `git diff --check` which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5393c791748330ac968863799a9fba)