### PR TITLE
feat: add evidence registry and integrity verification

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,15 +18,7 @@ jobs:
           globs: |
             **/*.md
             !node_modules
-          config: |
-            {
-              "default": true,
-              "MD013": false,
-              "MD024": { "siblings_only": true },
-              "MD025": false,
-              "MD033": false,
-              "MD041": false
-            }
+          config: .markdownlint.json
 
   yaml-frontmatter:
     name: SKILL.md YAML frontmatter

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD025": false,
+  "MD033": false,
+  "MD041": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Append-only evidence registration with SHA-256 and size recording, local artifact verification, path-containment and symlink protections, and `outrider evidence` CLI commands.
+
 - Stable UUID-backed run manifests, append-only schema-versioned workflow state events, validated workflow transitions, and explicit legacy-run bootstrap commands.
 
 - Add deterministic scope-file validation with exact-domain, wildcard-subdomain, exact-IP, and CIDR matching.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,33 @@ Scope → Recon → Enrich → Bug Bounty Intel → Score → Finding Cards → 
 
 ---
 
+
+## Evidence registry
+
+Outrider run folders include an append-only `evidence.jsonl` registry and an `artifacts/` directory for local evidence artifacts. Artifact contents remain in `artifacts/`; the registry stores only metadata, provenance, paths, SHA-256 hashes, and sizes.
+
+```bash
+outrider init example.com --actor authorized-operator --authorization-reference EXAMPLE-ROE-001
+mkdir -p runs/example.com/artifacts/http
+printf 'HTTP/1.1 200 OK\n' \
+  > runs/example.com/artifacts/http/homepage-response.txt
+
+outrider evidence register \
+  runs/example.com \
+  artifacts/http/homepage-response.txt \
+  --actor authorized-operator \
+  --type http-response \
+  --media-type text/plain \
+  --source manual-capture
+
+outrider evidence list runs/example.com
+outrider evidence verify runs/example.com
+```
+
+Evidence files must be beneath `artifacts/`. Absolute paths, traversal, symlinks, symlinked parents, directories, and Outrider control files are rejected. Duplicate paths are rejected; if an artifact is updated, save it under a new filename and register that path instead of changing an old registry entry.
+
+Evidence registration does not grant authorization or approval, does not change run state, does not append to `run.jsonl`, and does not perform scope checks. Verification is local, read-only, and performs no network activity. Run folders and evidence artifacts are operational output and must never be committed.
+
 ## Disclosed Report Intelligence
 
 Outrider includes a public bug-bounty intelligence layer. It can query HackerOne Hacktivity public disclosures and use prior real-world reports as technique references during recon.

--- a/docs/adr/0002-evidence-registry-and-integrity.md
+++ b/docs/adr/0002-evidence-registry-and-integrity.md
@@ -1,0 +1,39 @@
+# ADR 0002: Evidence registry and integrity verification
+
+## Status
+
+Accepted.
+
+## Context
+
+Outrider run folders already separate stable run identity (`manifest.json`) from append-only workflow state (`run.jsonl`). Operators also need deterministic offline registration of local evidence artifacts so later review can detect missing, modified, malformed, or unsafe artifact paths without adding recon execution, approval semantics, network behavior, a database, or a web interface.
+
+## Decision
+
+Outrider uses a dedicated append-only `evidence.jsonl` registry in each run folder. Each line is one `evidence_registered` JSON object with schema version 1, an independent evidence sequence, UUID4 evidence ID, manifest run ID, UTC registration timestamp, actor, relative artifact path, artifact type, SHA-256 hash, size, and optional provenance notes.
+
+Artifact contents live under `artifacts/`. The registry stores only metadata, provenance, paths, sizes, and hashes. It does not store artifact contents.
+
+`evidence.jsonl` is intentionally separate from:
+
+- `manifest.json`, which remains stable run identity metadata and is not rewritten during evidence registration;
+- `run.jsonl`, which remains the append-only workflow-state authority and does not receive evidence records.
+
+Evidence hashing uses Python standard-library streaming SHA-256 over bounded binary chunks. The implementation derives `size_bytes` from the bytes hashed and checks file metadata before and after hashing to detect changes when reasonably possible.
+
+Evidence paths must be canonical relative POSIX paths beneath `artifacts/`. Absolute paths, traversal, control files, directories, symlinks, symlinked parent directories, and non-regular files are rejected. Registration and verification do not follow symlinks.
+
+A registered path may appear only once. Updated or replaced artifacts require a new artifact filename and a new registry entry.
+
+Verification re-hashes selected artifacts, compares both SHA-256 and size, and reports `verified`, `missing`, `mismatch`, or `unsafe`. Verification is read-only and available for archived runs.
+
+Evidence registration requires a valid manifest and a valid workflow state stream. It is allowed in any valid state except `archived`; archived runs reject new evidence registration.
+
+## Consequences and limitations
+
+- Evidence registration is append-only in normal operation and flushes/fsyncs appended records for durability.
+- There is no filesystem immutability guarantee; operators and host controls remain responsible for protecting artifact files.
+- There is no concurrent-writer guarantee in this decision.
+- Evidence registration does not grant authorization, infer approval, or validate whether collecting an artifact was authorized.
+- Evidence registration does not perform finding validation and does not classify findings.
+- Evidence registration and verification perform no network activity.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,13 +7,13 @@ This document describes both implemented behavior and architectural design inten
 | Domain | Current status | Version source | Notes |
 |---|---|---|---|
 | Claude plugin/content release | Implemented as the skill bundle, plugin manifest, docs, examples, install scripts, and optional MCP companion listed in the changelog. | `CHANGELOG.md` and `.claude-plugin/plugin.json` | This release domain tracks the packaged Claude-facing content. |
-| Python CLI package | Implemented as run-folder scaffolding, deterministic scope validation, stable run manifests, append-only workflow-state events, and validated state transitions. | `pyproject.toml` and `outrider/__init__.py` | The CLI validates local scope and workflow state; it does not implement approvals, evidence integrity, MCP enforcement, recon execution, or a web UI. |
+| Python CLI package | Implemented as run-folder scaffolding, deterministic scope validation, stable run manifests, append-only workflow-state events, validated state transitions, append-only evidence registration, and SHA-256 artifact integrity verification. | `pyproject.toml` and `outrider/__init__.py` | The CLI validates local scope and workflow state; it does not implement approvals, MCP enforcement, recon execution, finding validation, or a web UI. |
 | Individual skill frontmatter | Implemented per `skills/*/SKILL.md`. | Each skill's YAML `version:` field | Skill versions may differ from the plugin/content release and from the Python package version. |
 | MCP server | Implemented as optional live enrichment. | MCP server files and dependency metadata | The MCP server provides live lookup tools but does not currently enforce scope. |
 
 These version domains do not have to use the same number. A plugin/content release can advance independently from the Python CLI package, individual skill frontmatter, or MCP implementation.
 
-The asset graph, output schema, sidecar coordination, validator discipline, and approval/scope concepts below are the intended architecture. Some are implemented as Claude skill instructions and documentation today; deterministic Python enforcement now covers scope validation and workflow-state validation where explicitly described in code. Approval enforcement, evidence integrity, MCP enforcement, recon execution, and a web UI are not implemented.
+The asset graph, output schema, sidecar coordination, validator discipline, and approval/scope concepts below are the intended architecture. Some are implemented as Claude skill instructions and documentation today; deterministic Python enforcement now covers scope validation and workflow-state validation where explicitly described in code. Approval enforcement, MCP enforcement, recon execution, finding validation, and a web UI are not implemented.
 
 ## The router + sub-skill split
 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if [ -d "$INSTALL_DIR/skills/offensive-osint/scripts" ]; then
   cp "$INSTALL_DIR/skills/offensive-osint/scripts/"*.py "$SKILLS_DIR/offensive-osint/scripts/" 2>/dev/null || true
 fi
 
-SKILL_COUNT=$(ls -d "$SKILLS_DIR"/*/SKILL.md 2>/dev/null | wc -l)
+SKILL_COUNT=$(find "$SKILLS_DIR" -mindepth 2 -maxdepth 2 -type f -name SKILL.md 2>/dev/null | wc -l)
 echo ""
 echo "Done! $SKILL_COUNT skills installed."
 echo "Start a new Claude Code session and try:"

--- a/outrider/cli.py
+++ b/outrider/cli.py
@@ -6,6 +6,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from outrider.evidence import (
+    EvidenceRegistrationError,
+    EvidenceValidationError,
+    load_evidence_registry,
+    register_evidence,
+    verify_all_evidence,
+    verify_evidence,
+)
 from outrider.scope import evaluate_scope_path
 from outrider.state import InvalidTransitionError, StateValidationError, bootstrap_legacy_run, initialize_state, load_state, transition_state
 
@@ -209,6 +217,14 @@ def init_run(args: argparse.Namespace) -> int:
             initialize_state(run_dir, target, args.actor, args.authorization_reference)
             created.append("manifest.json")
 
+    evidence_path = run_dir / "evidence.jsonl"
+    if not evidence_path.exists():
+        evidence_path.touch()
+        created.append("evidence.jsonl")
+    artifacts_path = run_dir / "artifacts"
+    if not artifacts_path.exists():
+        artifacts_path.mkdir()
+        created.append("artifacts/")
 
     for filename, payload in DEFAULT_FILES.items():
         if write_if_missing(run_dir / filename, json.dumps(payload, indent=2, sort_keys=True) + "\n"):
@@ -240,7 +256,7 @@ def show_run(args: argparse.Namespace) -> int:
     if not run_dir.exists():
         print(f"Run folder not found: {run_dir}")
         return 1
-    expected = ["manifest.json", "scope.yaml", "run.jsonl", "assets.json", "web_surface.json", "identity_fabric.json", "bb_intel.json", "findings.md", "technique_cards.md", "surface.md", "report.md"]
+    expected = ["manifest.json", "scope.yaml", "run.jsonl", "evidence.jsonl", "artifacts", "assets.json", "web_surface.json", "identity_fabric.json", "bb_intel.json", "findings.md", "technique_cards.md", "surface.md", "report.md"]
     print(f"Outrider run: {run_dir}")
     for filename in expected:
         marker = "ok" if (run_dir / filename).exists() else "missing"
@@ -320,6 +336,66 @@ def state_bootstrap(args: argparse.Namespace) -> int:
         return 2
 
 
+
+def evidence_register(args: argparse.Namespace) -> int:
+    try:
+        record = register_evidence(args.run_dir, args.relative_path, args.actor, args.artifact_type, args.media_type, args.source, args.note)
+    except EvidenceRegistrationError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    except (EvidenceValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    if args.json:
+        print(json.dumps(record.to_dict(), sort_keys=True))
+    else:
+        print("Evidence registered")
+        print(f"Evidence ID: {record.evidence_id}")
+        print(f"Run ID: {record.run_id}")
+        print(f"Path: {record.path}")
+        print(f"Artifact type: {record.artifact_type}")
+        print(f"SHA-256: {record.sha256}")
+        print(f"Size: {record.size_bytes}")
+        print(f"Actor: {record.actor}")
+    return 0
+
+
+def evidence_list(args: argparse.Namespace) -> int:
+    try:
+        summary = load_evidence_registry(args.run_dir)
+    except (EvidenceValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    if args.json:
+        print(json.dumps(summary.to_dict(), sort_keys=True))
+    else:
+        print(f"Run ID: {summary.run_id}")
+        print(f"Evidence count: {summary.evidence_count}")
+        for record in summary.records:
+            print(f"{record.sequence}: {record.evidence_id} {record.path} {record.artifact_type} {record.sha256} {record.size_bytes} {record.actor} {record.registered_at}")
+    return 0
+
+
+def evidence_verify_cmd(args: argparse.Namespace) -> int:
+    try:
+        results = (verify_evidence(args.run_dir, args.evidence_id),) if args.evidence_id else verify_all_evidence(args.run_dir)
+    except (EvidenceValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    if args.json:
+        print(json.dumps({"results": [item.to_dict() for item in results]}, sort_keys=True))
+    else:
+        for item in results:
+            print(f"Evidence ID: {item.evidence_id}")
+            print(f"Path: {item.path or 'n/a'}")
+            print(f"Expected SHA-256: {item.expected_sha256 or 'n/a'}")
+            print(f"Actual SHA-256: {item.actual_sha256 or 'n/a'}")
+            print(f"Expected size: {item.expected_size}")
+            print(f"Actual size: {item.actual_size if item.actual_size is not None else 'n/a'}")
+            print(f"Status: {item.status}")
+            print(f"Reason: {item.reason}")
+    return 0 if all(item.status == "verified" for item in results) else 1
+
 def scope_check(args: argparse.Namespace) -> int:
     decision = evaluate_scope_path(args.run_dir, args.candidate)
     if args.json:
@@ -359,6 +435,28 @@ def build_parser() -> argparse.ArgumentParser:
     scope_parser.add_argument("candidate", help="Domain, IP address, or URL to evaluate.")
     scope_parser.add_argument("--json", action="store_true", help="Emit the structured scope decision as JSON.")
     scope_parser.set_defaults(func=scope_check)
+
+    evidence_parser = subcommands.add_parser("evidence", help="Register, list, and verify local evidence artifacts.")
+    evidence_sub = evidence_parser.add_subparsers(dest="evidence_command", required=True)
+    evidence_register_parser = evidence_sub.add_parser("register", help="Append an evidence registry record for an artifact.")
+    evidence_register_parser.add_argument("run_dir")
+    evidence_register_parser.add_argument("relative_path")
+    evidence_register_parser.add_argument("--actor", required=True)
+    evidence_register_parser.add_argument("--type", dest="artifact_type", required=True)
+    evidence_register_parser.add_argument("--media-type")
+    evidence_register_parser.add_argument("--source")
+    evidence_register_parser.add_argument("--note")
+    evidence_register_parser.add_argument("--json", action="store_true")
+    evidence_register_parser.set_defaults(func=evidence_register)
+    evidence_list_parser = evidence_sub.add_parser("list", help="List registered evidence.")
+    evidence_list_parser.add_argument("run_dir")
+    evidence_list_parser.add_argument("--json", action="store_true")
+    evidence_list_parser.set_defaults(func=evidence_list)
+    evidence_verify_parser = evidence_sub.add_parser("verify", help="Verify registered artifacts.")
+    evidence_verify_parser.add_argument("run_dir")
+    evidence_verify_parser.add_argument("--evidence-id")
+    evidence_verify_parser.add_argument("--json", action="store_true")
+    evidence_verify_parser.set_defaults(func=evidence_verify_cmd)
 
     state_parser = subcommands.add_parser("state", help="Show or transition durable run workflow state.")
     state_sub = state_parser.add_subparsers(dest="state_command", required=True)

--- a/outrider/evidence.py
+++ b/outrider/evidence.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+from typing import Any
+from uuid import UUID, uuid4
+
+from outrider.state import RunManifest, StateValidationError, load_manifest, load_state
+
+SCHEMA_VERSION = 1
+EVENT_TYPE = "evidence_registered"
+REGISTRY_FILE = "evidence.jsonl"
+ARTIFACTS_DIR = "artifacts"
+ARTIFACT_TYPE_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+CHUNK_SIZE = 1024 * 1024
+
+
+class EvidenceValidationError(ValueError):
+    pass
+
+
+class EvidenceRegistrationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    schema_version: int
+    sequence: int
+    event_type: str
+    evidence_id: str
+    run_id: str
+    registered_at: str
+    actor: str
+    path: str
+    artifact_type: str
+    sha256: str
+    size_bytes: int
+    media_type: str | None
+    source: str | None
+    note: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EvidenceRegistrySummary:
+    run_id: str
+    evidence_count: int
+    records: tuple[EvidenceRecord, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"run_id": self.run_id, "evidence_count": self.evidence_count, "records": [r.to_dict() for r in self.records]}
+
+
+@dataclass(frozen=True)
+class EvidenceVerification:
+    evidence_id: str
+    path: str
+    expected_sha256: str
+    actual_sha256: str | None
+    expected_size: int
+    actual_size: int | None
+    status: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def ensure_evidence_storage(run_dir: str | Path) -> None:
+    run_path = Path(run_dir)
+    (run_path / ARTIFACTS_DIR).mkdir(exist_ok=True)
+    registry = run_path / REGISTRY_FILE
+    if not registry.exists():
+        registry.touch()
+
+
+def _nonempty(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceValidationError(f"{field} must be a non-empty string")
+    return value
+
+
+def _optional_nonempty(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    return _nonempty(value, field)
+
+
+def _timestamp(value: Any) -> str:
+    if not isinstance(value, str):
+        raise EvidenceValidationError("registered_at must be a string timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise EvidenceValidationError("registered_at must be a valid ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise EvidenceValidationError("registered_at must be timezone-aware")
+    return value
+
+
+def _uuid4(value: Any) -> str:
+    if not isinstance(value, str):
+        raise EvidenceValidationError("evidence_id must be a UUID string")
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise EvidenceValidationError("evidence_id must be a valid UUID") from exc
+    if parsed.version != 4:
+        raise EvidenceValidationError("evidence_id must be a UUID version 4")
+    return value
+
+
+def normalize_evidence_path(relative_path: str) -> str:
+    if not isinstance(relative_path, str) or not relative_path:
+        raise EvidenceValidationError("path must be a non-empty relative path")
+    text = relative_path.replace("\\", "/")
+    pure = PurePosixPath(text)
+    if pure.is_absolute() or text in {".", ".."} or any(part in {"", ".", ".."} for part in pure.parts):
+        raise EvidenceValidationError("path must be a canonical relative POSIX path without traversal")
+    if not pure.parts or pure.parts[0] != ARTIFACTS_DIR or len(pure.parts) == 1:
+        raise EvidenceValidationError("evidence path must be beneath artifacts/")
+    return pure.as_posix()
+
+
+def _validate_artifact_path(run_dir: Path, relative_path: str) -> tuple[str, Path]:
+    normalized = normalize_evidence_path(relative_path)
+    run_real = run_dir.resolve(strict=True)
+    artifact = run_dir / normalized
+    try:
+        resolved = artifact.resolve(strict=False)
+        resolved.relative_to(run_real)
+    except ValueError as exc:
+        raise EvidenceValidationError("evidence path escapes the run folder") from exc
+    parent = run_dir
+    for part in PurePosixPath(normalized).parts[:-1]:
+        parent = parent / part
+        try:
+            st = parent.lstat()
+        except FileNotFoundError as exc:
+            raise EvidenceValidationError("artifact parent directory does not exist") from exc
+        if stat.S_ISLNK(st.st_mode):
+            raise EvidenceValidationError("artifact parent directories must not be symlinks")
+        if not stat.S_ISDIR(st.st_mode):
+            raise EvidenceValidationError("artifact parent path must be a directory")
+    try:
+        st = artifact.lstat()
+    except FileNotFoundError as exc:
+        raise EvidenceValidationError("artifact file not found") from exc
+    if stat.S_ISLNK(st.st_mode):
+        raise EvidenceValidationError("artifact must not be a symlink")
+    if stat.S_ISDIR(st.st_mode):
+        raise EvidenceValidationError("artifact path is a directory")
+    if not stat.S_ISREG(st.st_mode):
+        raise EvidenceValidationError("artifact must be a regular file")
+    return normalized, artifact
+
+
+def _hash_regular_file(path: Path) -> tuple[str, int]:
+    before = path.lstat()
+    if not stat.S_ISREG(before.st_mode) or stat.S_ISLNK(before.st_mode):
+        raise EvidenceValidationError("artifact must remain a regular file")
+    digest = hashlib.sha256(); size = 0
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            size += len(chunk); digest.update(chunk)
+    after = path.lstat()
+    if not stat.S_ISREG(after.st_mode) or stat.S_ISLNK(after.st_mode):
+        raise EvidenceValidationError("artifact changed type while being hashed")
+    before_tuple = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+    after_tuple = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+    if before_tuple != after_tuple or size != after.st_size:
+        raise EvidenceValidationError("artifact changed while being hashed")
+    return digest.hexdigest(), size
+
+
+def _parse_record(data: Any, manifest: RunManifest, expected_sequence: int, seen_ids: set[str], seen_paths: set[str]) -> EvidenceRecord:
+    if not isinstance(data, dict):
+        raise EvidenceValidationError("evidence record must be a JSON object")
+    required = ["schema_version", "sequence", "event_type", "evidence_id", "run_id", "registered_at", "actor", "path", "artifact_type", "sha256", "size_bytes", "media_type", "source", "note"]
+    for key in required:
+        if key not in data:
+            raise EvidenceValidationError(f"evidence record missing required field: {key}")
+    if data["schema_version"] != SCHEMA_VERSION:
+        raise EvidenceValidationError("unsupported evidence schema_version")
+    if not isinstance(data["sequence"], int) or data["sequence"] != expected_sequence:
+        raise EvidenceValidationError("evidence sequence must increment by exactly one")
+    if data["event_type"] != EVENT_TYPE:
+        raise EvidenceValidationError("unknown evidence event_type")
+    evidence_id = _uuid4(data["evidence_id"])
+    if evidence_id in seen_ids:
+        raise EvidenceValidationError("duplicate evidence_id in registry")
+    seen_ids.add(evidence_id)
+    if data["run_id"] != manifest.run_id:
+        raise EvidenceValidationError("evidence run_id does not match manifest")
+    registered_at = _timestamp(data["registered_at"])
+    actor = _nonempty(data["actor"], "actor")
+    path = normalize_evidence_path(data["path"])
+    if path in seen_paths:
+        raise EvidenceValidationError("duplicate evidence path in registry")
+    seen_paths.add(path)
+    artifact_type = _nonempty(data["artifact_type"], "artifact_type")
+    if not ARTIFACT_TYPE_RE.fullmatch(artifact_type):
+        raise EvidenceValidationError("artifact_type must match [a-z][a-z0-9_-]{0,63}")
+    sha256 = data["sha256"]
+    if not isinstance(sha256, str) or not SHA256_RE.fullmatch(sha256):
+        raise EvidenceValidationError("sha256 must be 64 lowercase hexadecimal characters")
+    size_bytes = data["size_bytes"]
+    if not isinstance(size_bytes, int) or size_bytes < 0:
+        raise EvidenceValidationError("size_bytes must be a non-negative integer")
+    media_type = _optional_nonempty(data["media_type"], "media_type")
+    source = _optional_nonempty(data["source"], "source")
+    note = _optional_nonempty(data["note"], "note")
+    return EvidenceRecord(SCHEMA_VERSION, data["sequence"], EVENT_TYPE, evidence_id, manifest.run_id, registered_at, actor, path, artifact_type, sha256, size_bytes, media_type, source, note)
+
+
+def load_evidence_registry(run_dir: str | Path) -> EvidenceRegistrySummary:
+    manifest = load_manifest(run_dir)
+    try:
+        load_state(run_dir)
+    except StateValidationError as exc:
+        raise EvidenceValidationError(str(exc)) from exc
+    path = Path(run_dir) / REGISTRY_FILE
+    if not path.exists():
+        return EvidenceRegistrySummary(manifest.run_id, 0, ())
+    records: list[EvidenceRecord] = []; seen_ids: set[str] = set(); seen_paths: set[str] = set(); started = False
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if raw == "":
+            if started:
+                raise EvidenceValidationError(f"blank line in evidence registry at line {lineno}")
+            continue
+        started = True
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise EvidenceValidationError(f"malformed JSON in evidence registry at line {lineno}: {exc}") from exc
+        records.append(_parse_record(data, manifest, len(records) + 1, seen_ids, seen_paths))
+    return EvidenceRegistrySummary(manifest.run_id, len(records), tuple(records))
+
+
+def register_evidence(run_dir: str | Path, relative_path: str, actor: str, artifact_type: str, media_type: str | None = None, source: str | None = None, note: str | None = None) -> EvidenceRecord:
+    run_path = Path(run_dir)
+    manifest = load_manifest(run_path)
+    try:
+        state = load_state(run_path)
+    except StateValidationError as exc:
+        raise EvidenceValidationError(str(exc)) from exc
+    if state.current_state == "archived":
+        raise EvidenceRegistrationError("archived runs do not accept new evidence")
+    summary = load_evidence_registry(run_path)
+    actor = _nonempty(actor, "actor")
+    if not ARTIFACT_TYPE_RE.fullmatch(_nonempty(artifact_type, "artifact_type")):
+        raise EvidenceValidationError("artifact_type must match [a-z][a-z0-9_-]{0,63}")
+    media_type = _optional_nonempty(media_type, "media_type")
+    source = _optional_nonempty(source, "source")
+    note = _optional_nonempty(note, "note")
+    normalized, artifact = _validate_artifact_path(run_path, relative_path)
+    if any(record.path == normalized for record in summary.records):
+        raise EvidenceRegistrationError("evidence path is already registered")
+    sha256, size = _hash_regular_file(artifact)
+    record = EvidenceRecord(SCHEMA_VERSION, summary.evidence_count + 1, EVENT_TYPE, str(uuid4()), manifest.run_id, utc_now(), actor, normalized, artifact_type, sha256, size, media_type, source, note)
+    ensure_evidence_storage(run_path)
+    with (run_path / REGISTRY_FILE).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record.to_dict(), sort_keys=True) + "\n")
+        handle.flush(); os.fsync(handle.fileno())
+    return record
+
+
+def verify_evidence(run_dir: str | Path, evidence_id: str) -> EvidenceVerification:
+    summary = load_evidence_registry(run_dir)
+    for record in summary.records:
+        if record.evidence_id == evidence_id:
+            return _verify_record(Path(run_dir), record)
+    return EvidenceVerification(evidence_id, "", "", None, 0, None, "missing", "evidence ID not found")
+
+
+def verify_all_evidence(run_dir: str | Path) -> tuple[EvidenceVerification, ...]:
+    summary = load_evidence_registry(run_dir)
+    return tuple(_verify_record(Path(run_dir), record) for record in summary.records)
+
+
+def _verify_record(run_dir: Path, record: EvidenceRecord) -> EvidenceVerification:
+    try:
+        _, artifact = _validate_artifact_path(run_dir, record.path)
+        actual_sha, actual_size = _hash_regular_file(artifact)
+    except EvidenceValidationError as exc:
+        reason = str(exc)
+        status = "missing" if "not found" in reason or "does not exist" in reason else "unsafe"
+        return EvidenceVerification(record.evidence_id, record.path, record.sha256, None, record.size_bytes, None, status, reason)
+    if actual_sha == record.sha256 and actual_size == record.size_bytes:
+        return EvidenceVerification(record.evidence_id, record.path, record.sha256, actual_sha, record.size_bytes, actual_size, "verified", "artifact matches registered hash and size")
+    return EvidenceVerification(record.evidence_id, record.path, record.sha256, actual_sha, record.size_bytes, actual_size, "mismatch", "artifact hash or size differs from registry")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,8 @@ class CliCommandTests(unittest.TestCase):
         "manifest.json",
         "scope.yaml",
         "run.jsonl",
+        "evidence.jsonl",
+        "artifacts",
         *expected_json_sidecars,
         *expected_markdown_templates,
     }
@@ -151,6 +153,58 @@ class CliCommandTests(unittest.TestCase):
             invalid_status, invalid_output = self.run_cli("scope-check", str(run_dir), "example.com")
             self.assertEqual(invalid_status, 2)
             self.assertIn("ERROR", invalid_output)
+
+
+    def test_evidence_cli_register_list_verify_and_error_codes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status, _ = self.run_cli("init", "example.com", "--output-dir", tmpdir, "--actor", "authorized-operator", "--authorization-reference", "EXAMPLE-ROE-001")
+            self.assertEqual(status, 0)
+            run_dir = Path(tmpdir) / "example.com"
+            artifact = run_dir / "artifacts" / "http" / "homepage-response.txt"
+            artifact.parent.mkdir()
+            artifact.write_text("HTTP/1.1 200 OK\n", encoding="utf-8")
+
+            reg_status, reg_output = self.run_cli("evidence", "register", str(run_dir), "artifacts/http/homepage-response.txt", "--actor", "authorized-operator", "--type", "http-response", "--media-type", "text/plain", "--source", "manual-capture", "--json")
+            self.assertEqual(reg_status, 0)
+            record = json.loads(reg_output)
+            self.assertEqual(record["path"], "artifacts/http/homepage-response.txt")
+
+            list_status, list_output = self.run_cli("evidence", "list", str(run_dir))
+            self.assertEqual(list_status, 0)
+            self.assertIn(record["evidence_id"], list_output)
+            self.assertIn(record["path"], list_output)
+            json_list_status, json_list = self.run_cli("evidence", "list", str(run_dir), "--json")
+            self.assertEqual(json_list_status, 0)
+            self.assertEqual(json.loads(json_list)["evidence_count"], 1)
+
+            verify_status, verify_output = self.run_cli("evidence", "verify", str(run_dir))
+            self.assertEqual(verify_status, 0)
+            self.assertIn("Status: verified", verify_output)
+            artifact.write_text("changed\n", encoding="utf-8")
+            changed_status, _ = self.run_cli("evidence", "verify", str(run_dir))
+            self.assertEqual(changed_status, 1)
+            artifact.unlink()
+            missing_status, _ = self.run_cli("evidence", "verify", str(run_dir))
+            self.assertEqual(missing_status, 1)
+            unknown_status, _ = self.run_cli("evidence", "verify", str(run_dir), "--evidence-id", "00000000-0000-4000-8000-000000000000")
+            self.assertEqual(unknown_status, 1)
+
+            artifact.write_text("new\n", encoding="utf-8")
+            dup_status, _ = self.run_cli("evidence", "register", str(run_dir), "artifacts/http/homepage-response.txt", "--actor", "authorized-operator", "--type", "http-response")
+            self.assertEqual(dup_status, 1)
+            bad_status, bad_output = self.run_cli("evidence", "register", str(run_dir), "../outside.txt", "--actor", "authorized-operator", "--type", "http-response")
+            self.assertEqual(bad_status, 2)
+            self.assertNotIn("Traceback", bad_output)
+            (run_dir / "evidence.jsonl").write_text("{bad\n", encoding="utf-8")
+            malformed_status, _ = self.run_cli("evidence", "list", str(run_dir))
+            self.assertEqual(malformed_status, 2)
+
+    def test_empty_evidence_list_and_verify_succeed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.assertEqual(self.run_cli("init", "example.com", "--output-dir", tmpdir)[0], 0)
+            run_dir = Path(tmpdir) / "example.com"
+            self.assertEqual(self.run_cli("evidence", "list", str(run_dir))[0], 0)
+            self.assertEqual(self.run_cli("evidence", "verify", str(run_dir))[0], 0)
 
     def test_show_returns_failure_for_missing_run_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,175 @@
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from uuid import UUID
+
+from outrider.cli import init_run
+from argparse import Namespace
+from outrider.evidence import EvidenceRegistrationError, EvidenceValidationError, load_evidence_registry, register_evidence, verify_all_evidence, verify_evidence
+from outrider.state import load_manifest, load_state, transition_state
+
+
+class EvidenceTests(unittest.TestCase):
+    def make_run(self):
+        tmp = tempfile.TemporaryDirectory()
+        init_run(Namespace(target="example.com", output_dir=tmp.name, scope=None, exclude=None, actor="authorized-operator", authorization_reference="EXAMPLE-ROE-001"))
+        return tmp, Path(tmp.name) / "example.com"
+
+    def artifact(self, run_dir, name="artifacts/http/homepage-response.txt", data=b"HTTP/1.1 200 OK\n"):
+        path = run_dir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    def test_init_storage_rerun_preserves_registry_artifacts_manifest_and_state(self):
+        tmp, run_dir = self.make_run()
+        with tmp:
+            self.assertTrue((run_dir / "evidence.jsonl").is_file())
+            self.assertEqual((run_dir / "evidence.jsonl").read_text(), "")
+            self.assertTrue((run_dir / "artifacts").is_dir())
+            manifest_id = load_manifest(run_dir).run_id
+            events_before = (run_dir / "run.jsonl").read_text()
+            (run_dir / "evidence.jsonl").write_text('{"keep":true}\n')
+            self.artifact(run_dir, "artifacts/keep.txt", b"keep")
+            init_run(Namespace(target="example.com", output_dir=tmp.name, scope=None, exclude=None, actor=None, authorization_reference=None))
+            self.assertEqual((run_dir / "evidence.jsonl").read_text(), '{"keep":true}\n')
+            self.assertEqual((run_dir / "artifacts/keep.txt").read_bytes(), b"keep")
+            self.assertEqual(load_manifest(run_dir).run_id, manifest_id)
+            self.assertEqual((run_dir / "run.jsonl").read_text(), events_before)
+            (run_dir / "evidence.jsonl").unlink()
+            init_run(Namespace(target="example.com", output_dir=tmp.name, scope=None, exclude=None, actor=None, authorization_reference=None))
+            self.assertTrue((run_dir / "evidence.jsonl").exists())
+            self.assertEqual((run_dir / "run.jsonl").read_text(), events_before)
+
+    def test_register_text_binary_sequences_fields_and_no_state_or_manifest_change(self):
+        tmp, run_dir = self.make_run()
+        with tmp:
+            text = self.artifact(run_dir)
+            binary = self.artifact(run_dir, "artifacts/bin/blob.bin", b"\x00\xff\x01")
+            manifest_before = (run_dir / "manifest.json").read_text()
+            state_before = (run_dir / "run.jsonl").read_text()
+            r1 = register_evidence(run_dir, "artifacts/http/homepage-response.txt", "authorized-operator", "http-response", "text/plain", "manual-capture", "Initial response snapshot")
+            r2 = register_evidence(run_dir, "artifacts/bin/blob.bin", "authorized-operator", "other")
+            self.assertEqual(r1.sequence, 1); self.assertEqual(r2.sequence, 2)
+            self.assertEqual(UUID(r1.evidence_id).version, 4)
+            self.assertEqual(r1.run_id, load_manifest(run_dir).run_id)
+            self.assertIsNotNone(datetime.fromisoformat(r1.registered_at).tzinfo)
+            self.assertEqual(r1.actor, "authorized-operator"); self.assertEqual(r1.artifact_type, "http-response")
+            self.assertEqual(r1.media_type, "text/plain"); self.assertEqual(r1.source, "manual-capture"); self.assertEqual(r1.note, "Initial response snapshot")
+            self.assertEqual(r1.sha256, hashlib.sha256(text.read_bytes()).hexdigest())
+            self.assertEqual(r1.size_bytes, len(text.read_bytes()))
+            self.assertEqual(r2.sha256, hashlib.sha256(binary.read_bytes()).hexdigest())
+            self.assertEqual(len((run_dir / "evidence.jsonl").read_text().splitlines()), 2)
+            for line in (run_dir / "evidence.jsonl").read_text().splitlines():
+                self.assertIsInstance(json.loads(line), dict)
+            self.assertEqual((run_dir / "manifest.json").read_text(), manifest_before)
+            self.assertEqual((run_dir / "run.jsonl").read_text(), state_before)
+            self.assertEqual(load_state(run_dir).current_state, "initialized")
+
+    def test_reject_archived_duplicate_and_failed_registration_appends_nothing(self):
+        tmp, run_dir = self.make_run()
+        with tmp:
+            self.artifact(run_dir)
+            register_evidence(run_dir, "artifacts/http/homepage-response.txt", "authorized-operator", "http-response")
+            before = (run_dir / "evidence.jsonl").read_text()
+            with self.assertRaises(EvidenceRegistrationError):
+                register_evidence(run_dir, "artifacts/http/homepage-response.txt", "authorized-operator", "http-response")
+            self.assertEqual((run_dir / "evidence.jsonl").read_text(), before)
+            transition_state(run_dir, "scoped", "authorized-operator")
+            transition_state(run_dir, "collecting", "authorized-operator")
+            transition_state(run_dir, "analyzing", "authorized-operator")
+            transition_state(run_dir, "reporting", "authorized-operator")
+            transition_state(run_dir, "completed", "authorized-operator")
+            transition_state(run_dir, "archived", "authorized-operator")
+            self.artifact(run_dir, "artifacts/http/other.txt", b"x")
+            with self.assertRaises(EvidenceRegistrationError):
+                register_evidence(run_dir, "artifacts/http/other.txt", "authorized-operator", "http-response")
+            self.assertEqual((run_dir / "evidence.jsonl").read_text(), before)
+
+    def test_registry_validation_rejects_malformed_records(self):
+        tmp, run_dir = self.make_run()
+        with tmp:
+            self.artifact(run_dir)
+            r = register_evidence(run_dir, "artifacts/http/homepage-response.txt", "authorized-operator", "http-response")
+            good = r.to_dict()
+            cases = [
+                "{bad", "[]", json.dumps({**good, "sequence": 2}), json.dumps({**good, "run_id": "00000000-0000-4000-8000-000000000000"}),
+                json.dumps({**good, "evidence_id": "bad"}), json.dumps({**good, "evidence_id": "00000000-0000-1000-8000-000000000000"}),
+                json.dumps({**good, "registered_at": "not-date"}), json.dumps({**good, "artifact_type": "HTTP"}), json.dumps({**good, "artifact_type": "-bad"}),
+                json.dumps({**good, "sha256": "A"*64}), json.dumps({**good, "sha256": "0"*63}), json.dumps({**good, "size_bytes": -1}),
+                json.dumps({**good, "event_type": "other"}), json.dumps({k:v for k,v in good.items() if k != "actor"}), json.dumps({**good, "actor": 7}),
+            ]
+            for payload in cases:
+                with self.subTest(payload=payload[:30]):
+                    (run_dir / "evidence.jsonl").write_text(payload + "\n")
+                    with self.assertRaises(EvidenceValidationError):
+                        load_evidence_registry(run_dir)
+            (run_dir / "evidence.jsonl").write_text(json.dumps(good)+"\n\n")
+            with self.assertRaises(EvidenceValidationError): load_evidence_registry(run_dir)
+            other = {**good, "sequence": 2}
+            (run_dir / "evidence.jsonl").write_text(json.dumps(good)+"\n"+json.dumps(other)+"\n")
+            with self.assertRaises(EvidenceValidationError): load_evidence_registry(run_dir)
+            other = {**good, "sequence": 2, "evidence_id": "00000000-0000-4000-8000-000000000000"}
+            (run_dir / "evidence.jsonl").write_text(json.dumps(good)+"\n"+json.dumps(other)+"\n")
+            with self.assertRaises(EvidenceValidationError): load_evidence_registry(run_dir)
+
+    def test_path_safety_and_normalization(self):
+        tmp, run_dir = self.make_run()
+        with tmp:
+            self.artifact(run_dir)
+            before = (run_dir / "evidence.jsonl").read_text()
+            invalid = ["/tmp/x", "../outside.txt", "artifacts/../../outside.txt", "manifest.json", "run.jsonl", "scope.yaml", "evidence.jsonl", "artifacts/missing.txt", "artifacts"]
+            for path in invalid:
+                with self.subTest(path=path):
+                    with self.assertRaises(EvidenceValidationError): register_evidence(run_dir, path, "authorized-operator", "http-response")
+            (run_dir / "artifacts/dir").mkdir()
+            with self.assertRaises(EvidenceValidationError): register_evidence(run_dir, "artifacts/dir", "authorized-operator", "http-response")
+            os.symlink(run_dir / "artifacts/http/homepage-response.txt", run_dir / "artifacts/link.txt")
+            with self.assertRaises(EvidenceValidationError): register_evidence(run_dir, "artifacts/link.txt", "authorized-operator", "http-response")
+            outside = Path(tmp.name) / "outside"; outside.mkdir(); (outside / "x.txt").write_text("x")
+            os.symlink(outside, run_dir / "artifacts/symdir")
+            with self.assertRaises(EvidenceValidationError): register_evidence(run_dir, "artifacts/symdir/x.txt", "authorized-operator", "http-response")
+            fifo = run_dir / "artifacts/fifo"; os.mkfifo(fifo)
+            with self.assertRaises(EvidenceValidationError): register_evidence(run_dir, "artifacts/fifo", "authorized-operator", "http-response")
+            self.assertEqual((run_dir / "evidence.jsonl").read_text(), before)
+            r = register_evidence(run_dir, "artifacts/http/homepage-response.txt", "authorized-operator", "http-response")
+            self.assertEqual(r.path, "artifacts/http/homepage-response.txt")
+
+    def test_verification_statuses_selection_read_only_archived_empty(self):
+        tmp, run_dir = self.make_run()
+        with tmp:
+            a = self.artifact(run_dir, "artifacts/a.txt", b"a")
+            b = self.artifact(run_dir, "artifacts/b.txt", b"bb")
+            r1 = register_evidence(run_dir, "artifacts/a.txt", "authorized-operator", "other")
+            r2 = register_evidence(run_dir, "artifacts/b.txt", "authorized-operator", "other")
+            ev_before = (run_dir / "evidence.jsonl").read_text(); state_before = (run_dir / "run.jsonl").read_text()
+            self.assertEqual(verify_evidence(run_dir, r1.evidence_id).status, "verified")
+            b.write_bytes(b"changed")
+            results = verify_all_evidence(run_dir)
+            self.assertEqual([x.status for x in results], ["verified", "mismatch"])
+            self.assertEqual(verify_evidence(run_dir, r2.evidence_id).actual_size, len(b"changed"))
+            a.unlink()
+            self.assertEqual(verify_evidence(run_dir, r1.evidence_id).status, "missing")
+            b.unlink(); os.symlink(run_dir / "artifacts/a.txt", b)
+            self.assertEqual(verify_evidence(run_dir, r2.evidence_id).status, "unsafe")
+            self.assertEqual(verify_evidence(run_dir, "00000000-0000-4000-8000-000000000000").status, "missing")
+            self.assertEqual((run_dir / "evidence.jsonl").read_text(), ev_before)
+            self.assertEqual((run_dir / "run.jsonl").read_text(), state_before)
+            empty_tmp, empty_run = self.make_run()
+            with empty_tmp:
+                self.assertEqual(verify_all_evidence(empty_run), ())
+            transition_state(run_dir, "scoped", "authorized-operator")
+            transition_state(run_dir, "collecting", "authorized-operator")
+            transition_state(run_dir, "analyzing", "authorized-operator")
+            transition_state(run_dir, "reporting", "authorized-operator")
+            transition_state(run_dir, "completed", "authorized-operator")
+            transition_state(run_dir, "archived", "authorized-operator")
+            self.assertTrue(verify_all_evidence(run_dir))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a deterministic, offline, append-only evidence registry for run artifacts so operators can register, archive, and verify artifact integrity without altering run state or making network requests. 
- Record streaming SHA-256 and size metadata to detect missing, modified, malformed, or unsafe evidence paths while keeping artifact contents under `artifacts/` and separating registry metadata from `manifest.json` and `run.jsonl`.

### Description

- Add a reusable evidence module `outrider/evidence.py` implementing typed structures, registry loading/validation, streaming SHA-256 hashing, path-security checks (no absolute/traversal/symlink/non-regular files), append-only durable writes with `fsync`, and verification semantics (`verified`, `missing`, `mismatch`, `unsafe`).
- Extend the CLI (`outrider/cli.py`) with `outrider evidence register|list|verify` commands, human and JSON output modes, and run `init` updates to create `evidence.jsonl` and `artifacts/` when missing without modifying existing manifest or run state.
- Add comprehensive tests in `tests/test_evidence.py` and extend `tests/test_cli.py` to cover init behavior, registration (text/binary), schema and registry validation, path-safety rules, duplicate/archive handling, and verification behavior.
- Add documentation and metadata: `docs/adr/0002-evidence-registry-and-integrity.md`, README examples, architecture note, and a short changelog entry describing evidence features and constraints.

### Testing

- `python -m unittest discover -s tests -p "test_*.py"` — PASS (40 tests) using interpreter `/usr/bin/python3`.
- `/usr/bin/python3 -m compileall outrider tests` — PASS (byte-compile succeeded).
- `python -m pip check` — PASS (no broken requirements detected in the environment used for tests).
- `git diff --check` — PASS (no whitespace errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53a16624e48330856144caab810dd6)