### PR TITLE
feat: add deterministic finding promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,4 +299,6 @@ This project is a fork of [elementalsouls/Claude-OSINT](https://github.com/eleme
 
 ## Unreleased
 
+- Added append-only `findings.jsonl` validated-finding records with human-reviewed promotion from evidence-backed `finding_candidate` claims, source-result/source-claim provenance, source-result SHA-256 recording, evidence-integrity enforcement, current-scope and workflow-state checks, and finding list/show/verify CLI commands without automatic execution or automatic promotion.
+
 - Added versioned skill request/result contracts, a deterministic shipped-skill catalog, policy-aware request creation and validation, evidence-backed result validation with candidate/action assessments, and shared contract instructions for all shipped skills without adding skill execution or finding promotion.

--- a/README.md
+++ b/README.md
@@ -431,3 +431,35 @@ outrider contract result validate \
 ```
 
 Skill results must cite registered evidence IDs for claims rather than raw paths. Discovered candidates are observations only and do not expand `scope.yaml`. The `finding_candidate` classification is not a validated finding and is not promoted by these commands. The contract commands do not execute Claude skills, invoke MCP automatically, perform network activity, capture evidence automatically, or promote findings.
+
+## Deterministic finding promotion
+
+Outrider keeps skill-produced candidates separate from human-reviewed findings. Skills may emit `finding_candidate` claims in validated skill-result contracts, but only the Python control layer can append a `validated_finding` to `findings.jsonl`. Promotion requires a human reviewer to provide attribution, title, affected candidate, severity, confidence, validation basis, validation reason, impact, and remediation. Suggested severity and confidence in the source claim are advisory only.
+
+`findings.jsonl` is the append-only deterministic source of promoted findings. `findings.md` remains an operator-managed working document; automatic Markdown rendering is deferred. Promotion hashes the complete source result file with SHA-256, stores the source-result path and source-claim snapshot, verifies every referenced evidence artifact, requires the affected candidate to be currently in scope, and is allowed only during `analyzing` or `reporting`. The reviewer attribution string is not authenticated identity, and promotion performs no target action, HTTP request, DNS lookup, MCP invocation, approval grant, or automatic validation traffic.
+
+Example promotion:
+
+```sh
+outrider finding promote \
+  runs/example.com \
+  runs/example.com/contracts/results/RESULT_UUID.json \
+  CLAIM_UUID \
+  --actor authorized-operator \
+  --title "Public OpenAPI schema exposes internal API structure" \
+  --candidate api.example.com \
+  --location /openapi.json \
+  --severity medium \
+  --confidence high \
+  --validation-basis response_evidence \
+  --validation-reason "The registered response contains a valid OpenAPI schema." \
+  --impact "The schema exposes undocumented routes and object structures." \
+  --remediation "Restrict schema access and remove unnecessary production documentation."
+```
+
+List and verify promoted findings:
+
+```sh
+outrider finding list runs/example.com
+outrider finding verify runs/example.com
+```

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,3 +6,7 @@ Outrider skill contracts are local run artifacts under `contracts/requests/` and
 - `skill-result-v1.schema.json` documents result shape for `schema_version: 1`.
 
 The Python validator is the enforcement layer. It reloads the manifest, durable state, scope, approval records, and evidence registry on every validation.
+
+## Finding record v1
+
+`finding-v1.schema.json` documents each append-only `findings.jsonl` record. Skills do not write this contract: they may emit `finding_candidate` claims in `skill_result` v1 only. A `validated_finding` is created only by the Python finding promotion workflow after human review, current scope evaluation, workflow-state checks, source-result validation, source-result SHA-256 recording, and local evidence integrity verification. The registry is separate from `findings.md`, which remains operator-managed Markdown until a later reporting/export task.

--- a/contracts/finding-v1.schema.json
+++ b/contracts/finding-v1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outrider.local/contracts/finding-v1.schema.json",
+  "title": "Outrider finding v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "sequence", "event_type", "event_id", "finding_id", "run_id", "promoted_at", "promoted_by", "classification", "title", "affected_candidate", "candidate_type", "location", "severity", "confidence", "validation_basis", "validation_reason", "impact", "remediation", "source", "evidence_ids", "notes"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "sequence": {"type": "integer", "minimum": 1},
+    "event_type": {"const": "finding_promoted"},
+    "event_id": {"type": "string", "format": "uuid"},
+    "finding_id": {"type": "string", "format": "uuid"},
+    "run_id": {"type": "string", "format": "uuid"},
+    "promoted_at": {"type": "string", "format": "date-time"},
+    "promoted_by": {"type": "string", "minLength": 1},
+    "classification": {"const": "validated_finding"},
+    "title": {"type": "string", "minLength": 1},
+    "affected_candidate": {"type": "string", "minLength": 1},
+    "candidate_type": {"enum": ["domain", "ip"]},
+    "location": {"type": ["string", "null"], "minLength": 1},
+    "severity": {"enum": ["informational", "low", "medium", "high", "critical"]},
+    "confidence": {"enum": ["medium", "high"]},
+    "validation_basis": {"enum": ["evidence_review", "response_evidence", "configuration_evidence", "owner_confirmation"]},
+    "validation_reason": {"type": "string", "minLength": 1},
+    "impact": {"type": "string", "minLength": 1},
+    "remediation": {"type": "string", "minLength": 1},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["result_id", "request_id", "skill", "result_path", "result_sha256", "claim_id", "claim"],
+      "properties": {
+        "result_id": {"type": "string", "format": "uuid"},
+        "request_id": {"type": "string", "format": "uuid"},
+        "skill": {"type": "string", "minLength": 1},
+        "result_path": {"type": "string", "pattern": "^contracts/results/[^/]+$"},
+        "result_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "claim_id": {"type": "string", "format": "uuid"},
+        "claim": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["classification", "subject", "statement", "confidence", "suggested_severity", "evidence_ids"],
+          "properties": {
+            "classification": {"const": "finding_candidate"},
+            "subject": {"type": "string", "minLength": 1},
+            "statement": {"type": "string", "minLength": 1},
+            "confidence": {"enum": ["low", "medium", "high"]},
+            "suggested_severity": {"enum": ["informational", "low", "medium", "high", "critical", null]},
+            "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "format": "uuid"}}
+          }
+        }
+      }
+    },
+    "evidence_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "format": "uuid"}},
+    "notes": {"type": ["string", "null"], "minLength": 1}
+  }
+}

--- a/docs/adr/0006-deterministic-finding-promotion.md
+++ b/docs/adr/0006-deterministic-finding-promotion.md
@@ -1,0 +1,15 @@
+# ADR 0006: Deterministic finding promotion
+
+## Context
+
+Skill results can identify observations, exposures, hypotheses, and `finding_candidate` claims. A skill-produced candidate is not finding authority: Claude skills must not self-certify findings or claim exploitation, compromise, authenticated reviewer identity, digital authorization, client acceptance, or destructive validation.
+
+## Decision
+
+Outrider stores human-reviewed promoted findings in an append-only `findings.jsonl` registry. A `validated_finding` can be created only through the Python `outrider finding promote` workflow. Promotion requires human-supplied reviewer attribution and metadata, a valid source skill result and linked request, an exact `finding_candidate` source claim, source-result SHA-256 hashing, source-claim snapshot storage, registered evidence IDs whose artifacts verify locally, current deterministic scope allowance for the affected candidate, and a run state of `analyzing` or `reporting`.
+
+`findings.jsonl` is separate from `manifest.json`, `run.jsonl`, `evidence.jsonl`, approvals, skill contracts, and `findings.md`. `findings.md` remains operator-managed Markdown. Promotion performs no automatic execution, network validation traffic, DNS lookup, approval grant, state transition, evidence creation, or scope change. Severity remains a reviewer decision; source suggested severity is advisory.
+
+## Consequences and limitations
+
+The finding registry provides deterministic provenance and read-only verification of source-result presence, source-result hash, source-claim consistency, evidence-record presence, and artifact integrity. Later scope changes do not erase or rewrite historical findings; verification may report that a historically promoted finding is currently out of scope. This feature does not provide authenticated reviewers, digital signatures, client-acceptance semantics, update/delete lifecycle events, broad semantic duplicate detection, concurrent-writer guarantees, exploitation, or automatic Markdown rendering. The Python interface is reusable by future reporting, export, release, or web review planes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,4 +336,10 @@ Use the skills standalone (paste a SKILL.md into a Claude Project) or wired into
 
 Outrider currently implements deterministic scope validation, stable run identity with durable workflow state, evidence integrity checks, approval records with action-policy evaluation, MCP tool-boundary enforcement, and versioned skill request/result contracts. The contracts let Claude skills exchange structured task and result records with the Python control layer while Python remains authoritative for scope, state, approval, and evidence integrity.
 
-The contract layer does not implement automatic skill execution, automatic evidence capture, finding validation or promotion, concurrent orchestration, authenticated actors, or a web UI.
+The contract layer does not implement automatic skill execution, automatic evidence capture, concurrent orchestration, authenticated actors, or a web UI.
+
+## Implemented deterministic control layers
+
+Outrider implements deterministic scope validation, durable run identity and workflow state, evidence integrity, approval policy evaluation, MCP boundary enforcement, skill request/result contracts, and append-only evidence-backed finding promotion. Finding promotion records human-reviewed `validated_finding` entries in `findings.jsonl` with source-result SHA-256 provenance, source-claim snapshots, current-scope checks at promotion time, and local evidence verification.
+
+The architecture does not implement automatic vulnerability validation, exploitation, automatic candidate promotion, finding lifecycle updates, automatic Markdown rendering, client acceptance workflow, authenticated reviewers, concurrent-writer protection, or a web UI.

--- a/outrider/cli.py
+++ b/outrider/cli.py
@@ -14,6 +14,14 @@ from outrider.approval import (
     list_approvals,
     revoke_approval,
 )
+from outrider.finding import (
+    FindingPromotionRefusal,
+    FindingValidationError,
+    get_finding,
+    list_findings,
+    promote_finding,
+    verify_all_findings,
+)
 from outrider.evidence import (
     EvidenceRefusalError,
     EvidenceRegistrationError,
@@ -269,6 +277,8 @@ def init_run(args: argparse.Namespace) -> int:
         created.append("evidence.jsonl")
     if write_if_missing(run_dir / "approvals.jsonl", ""):
         created.append("approvals.jsonl")
+    if write_if_missing(run_dir / "findings.jsonl", ""):
+        created.append("findings.jsonl")
     artifacts_dir = run_dir / "artifacts"
     if not artifacts_dir.exists():
         artifacts_dir.mkdir()
@@ -312,6 +322,7 @@ def show_run(args: argparse.Namespace) -> int:
         "run.jsonl",
         "evidence.jsonl",
         "approvals.jsonl",
+        "findings.jsonl",
         "artifacts/",
         "contracts/",
         "contracts/requests/",
@@ -690,6 +701,109 @@ def contract_result_validate(args: argparse.Namespace) -> int:
     if report.structural_valid: return 1
     return 2
 
+
+def _print_finding_record(record, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(record.to_dict(), sort_keys=True))
+        return
+    print(f"Finding ID: {record.finding_id}")
+    print(f"Title: {record.title}")
+    print(f"Classification: {record.classification}")
+    print(f"Affected candidate: {record.affected_candidate}")
+    print(f"Severity: {record.severity}")
+    print(f"Confidence: {record.confidence}")
+    print(f"Promoted by: {record.promoted_by}")
+    print(f"Promoted at: {record.promoted_at}")
+    print(f"Source result ID: {record.source.result_id}")
+    print(f"Source claim ID: {record.source.claim_id}")
+    print(f"Evidence count: {len(record.evidence_ids)}")
+    print(f"Source result SHA-256: {record.source.result_sha256}")
+
+
+def finding_promote(args: argparse.Namespace) -> int:
+    try:
+        record = promote_finding(
+            args.run_dir, args.result_file, args.claim_id,
+            actor=args.actor, title=args.title, candidate=args.candidate,
+            severity=args.severity, confidence=args.confidence,
+            validation_basis=args.validation_basis,
+            validation_reason=args.validation_reason, impact=args.impact,
+            remediation=args.remediation, location=args.location, notes=args.notes,
+            supplementary_evidence_ids=args.evidence_id or [],
+        )
+        _print_finding_record(record, args.json)
+        return 0
+    except FindingPromotionRefusal as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    except (FindingValidationError, SkillContractValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
+
+def finding_list(args: argparse.Namespace) -> int:
+    try:
+        summary = list_findings(args.run_dir)
+        if args.json:
+            print(json.dumps(summary.to_dict(), sort_keys=True))
+        else:
+            print(f"Run ID: {summary.run_id}")
+            print(f"Finding count: {summary.finding_count}")
+            for r in summary.records:
+                print(f"{r.sequence} {r.finding_id} {r.title} {r.affected_candidate} {r.severity} {r.confidence} {r.source.skill} {r.promoted_at} {r.promoted_by}")
+        return 0
+    except (FindingValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
+
+def finding_show(args: argparse.Namespace) -> int:
+    try:
+        record = get_finding(args.run_dir, args.finding_id)
+        if record is None:
+            print("ERROR: finding_id is not registered")
+            return 1
+        if args.json:
+            print(json.dumps(record.to_dict(), sort_keys=True))
+        else:
+            _print_finding_record(record, False)
+            print(f"Location: {record.location or 'n/a'}")
+            print(f"Validation basis: {record.validation_basis}")
+            print(f"Validation reason: {record.validation_reason}")
+            print(f"Impact: {record.impact}")
+            print(f"Remediation: {record.remediation}")
+            print(f"Evidence IDs: {', '.join(record.evidence_ids)}")
+            print(f"Source request ID: {record.source.request_id}")
+            print(f"Source skill: {record.source.skill}")
+            print(f"Source result path: {record.source.result_path}")
+        return 0
+    except (FindingValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
+
+def finding_verify(args: argparse.Namespace) -> int:
+    try:
+        results = verify_all_findings(args.run_dir, args.finding_id)
+        ok = all(r.overall_status == "verified" for r in results)
+        if args.json:
+            print(json.dumps({"verified": ok, "results": [r.to_dict() for r in results]}, sort_keys=True))
+        else:
+            for r in results:
+                print(f"Finding ID: {r.finding_id}")
+                print(f"Title: {r.title or 'n/a'}")
+                print(f"Source-result status: {r.source_status}")
+                print(f"Expected source SHA-256: {r.expected_source_sha256 or 'n/a'}")
+                print(f"Actual source SHA-256: {r.actual_source_sha256 or 'n/a'}")
+                print(f"Evidence status: {r.evidence_status}")
+                print(f"Current-scope status: {r.current_scope_status}")
+                print(f"Overall status: {r.overall_status}")
+                print(f"Reason: {r.reason}")
+        return 0 if ok else 1
+    except (FindingValidationError, StateValidationError) as exc:
+        print(f"ERROR: {exc}")
+        return 2
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="outrider",
@@ -850,6 +964,43 @@ def build_parser() -> argparse.ArgumentParser:
     evidence_verify_parser.add_argument("--json", action="store_true")
     evidence_verify_parser.set_defaults(func=evidence_verify)
 
+
+
+
+    finding_parser = subcommands.add_parser("finding", help="Promote, list, show, and verify human-reviewed findings.")
+    finding_sub = finding_parser.add_subparsers(dest="finding_command", required=True)
+    finding_promote_parser = finding_sub.add_parser("promote", help="Promote a finding_candidate into a validated_finding.")
+    finding_promote_parser.add_argument("run_dir")
+    finding_promote_parser.add_argument("result_file")
+    finding_promote_parser.add_argument("claim_id")
+    finding_promote_parser.add_argument("--actor", required=True)
+    finding_promote_parser.add_argument("--title", required=True)
+    finding_promote_parser.add_argument("--candidate", required=True)
+    finding_promote_parser.add_argument("--severity", required=True)
+    finding_promote_parser.add_argument("--confidence", required=True)
+    finding_promote_parser.add_argument("--validation-basis", required=True)
+    finding_promote_parser.add_argument("--validation-reason", required=True)
+    finding_promote_parser.add_argument("--impact", required=True)
+    finding_promote_parser.add_argument("--remediation", required=True)
+    finding_promote_parser.add_argument("--location")
+    finding_promote_parser.add_argument("--notes")
+    finding_promote_parser.add_argument("--evidence-id", action="append")
+    finding_promote_parser.add_argument("--json", action="store_true")
+    finding_promote_parser.set_defaults(func=finding_promote)
+    finding_list_parser = finding_sub.add_parser("list", help="List promoted findings.")
+    finding_list_parser.add_argument("run_dir")
+    finding_list_parser.add_argument("--json", action="store_true")
+    finding_list_parser.set_defaults(func=finding_list)
+    finding_show_parser = finding_sub.add_parser("show", help="Show a promoted finding.")
+    finding_show_parser.add_argument("run_dir")
+    finding_show_parser.add_argument("finding_id")
+    finding_show_parser.add_argument("--json", action="store_true")
+    finding_show_parser.set_defaults(func=finding_show)
+    finding_verify_parser = finding_sub.add_parser("verify", help="Verify promoted finding provenance and evidence.")
+    finding_verify_parser.add_argument("run_dir")
+    finding_verify_parser.add_argument("--finding-id")
+    finding_verify_parser.add_argument("--json", action="store_true")
+    finding_verify_parser.set_defaults(func=finding_verify)
 
     contract_parser = subcommands.add_parser("contract", help="Create and validate skill interchange contracts.")
     contract_sub = contract_parser.add_subparsers(dest="contract_command", required=True)

--- a/outrider/finding.py
+++ b/outrider/finding.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+from typing import Any
+from uuid import UUID, uuid4
+
+from outrider.evidence import EvidenceValidationError, load_evidence_registry, verify_all_evidence
+from outrider.scope import evaluate_scope_path
+from outrider.skill_contract import SkillContractValidationError, load_skill_request, load_skill_result, validate_skill_result
+from outrider.state import StateValidationError, load_manifest, load_state
+
+SCHEMA_VERSION = 1
+REGISTRY = "findings.jsonl"
+EVENT_TYPE = "finding_promoted"
+CLASSIFICATION = "validated_finding"
+SOURCE_CLASSIFICATION = "finding_candidate"
+SEVERITIES = frozenset({"informational", "low", "medium", "high", "critical"})
+PROMOTED_CONFIDENCES = frozenset({"medium", "high"})
+VALIDATION_BASES = frozenset({"evidence_review", "response_evidence", "configuration_evidence", "owner_confirmation"})
+PROMOTION_STATES = frozenset({"analyzing", "reporting"})
+VERIFICATION_STATUSES = frozenset({"verified", "source_missing", "source_changed", "evidence_missing", "evidence_mismatch", "evidence_unsafe", "invalid"})
+SCOPE_STATUSES = frozenset({"currently_in_scope", "currently_out_of_scope", "scope_error"})
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_CHUNK = 1024 * 1024
+
+class FindingValidationError(ValueError): pass
+class FindingPromotionRefusal(ValueError): pass
+
+@dataclass(frozen=True)
+class FindingClaimSnapshot:
+    classification: str; subject: str; statement: str; confidence: str; suggested_severity: str | None; evidence_ids: list[str]
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+@dataclass(frozen=True)
+class FindingSource:
+    result_id: str; request_id: str; skill: str; result_path: str; result_sha256: str; claim_id: str; claim: FindingClaimSnapshot
+    def to_dict(self) -> dict[str, Any]:
+        d=asdict(self); d["claim"]=self.claim.to_dict(); return d
+
+@dataclass(frozen=True)
+class FindingRecord:
+    schema_version: int; sequence: int; event_type: str; event_id: str; finding_id: str; run_id: str; promoted_at: str; promoted_by: str; classification: str; title: str; affected_candidate: str; candidate_type: str; location: str | None; severity: str; confidence: str; validation_basis: str; validation_reason: str; impact: str; remediation: str; source: FindingSource; evidence_ids: list[str]; notes: str | None
+    def to_dict(self) -> dict[str, Any]:
+        d=asdict(self); d["source"]=self.source.to_dict(); return d
+
+@dataclass(frozen=True)
+class FindingRegistrySummary:
+    run_id: str; finding_count: int; records: tuple[FindingRecord, ...]
+    def to_dict(self) -> dict[str, Any]: return {"run_id": self.run_id, "finding_count": self.finding_count, "records": [r.to_dict() for r in self.records]}
+
+@dataclass(frozen=True)
+class FindingVerification:
+    finding_id: str; title: str; source_status: str; expected_source_sha256: str; actual_source_sha256: str | None; evidence_status: str; current_scope_status: str; overall_status: str; reason: str
+    def to_dict(self) -> dict[str, Any]: return asdict(self)
+
+def utc_now() -> str: return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+def _nonempty(v: Any, field: str) -> str:
+    if not isinstance(v, str) or not v.strip(): raise FindingValidationError(f"{field} must be a non-empty string")
+    return v
+
+def _optional(v: Any, field: str) -> str | None:
+    if v is None: return None
+    return _nonempty(v, field)
+
+def _uuid4(v: Any, field: str) -> str:
+    if not isinstance(v, str): raise FindingValidationError(f"{field} must be a UUID string")
+    try: u=UUID(v)
+    except ValueError as exc: raise FindingValidationError(f"{field} must be a valid UUID") from exc
+    if u.version != 4: raise FindingValidationError(f"{field} must be a UUID version 4")
+    return str(u)
+
+def _timestamp(v: Any) -> str:
+    if not isinstance(v, str): raise FindingValidationError("promoted_at must be a string timestamp")
+    try: dt=datetime.fromisoformat(v.replace("Z", "+00:00"))
+    except ValueError as exc: raise FindingValidationError("promoted_at must be a valid ISO-8601 timestamp") from exc
+    if dt.tzinfo is None or dt.utcoffset() is None: raise FindingValidationError("promoted_at must be timezone-aware")
+    return v
+
+def _unique_uuid_list(v: Any, field: str) -> list[str]:
+    if not isinstance(v, list) or not v: raise FindingValidationError(f"{field} must be a non-empty array")
+    ids=[_uuid4(x, field) for x in v]
+    if len(set(ids)) != len(ids): raise FindingValidationError(f"duplicate {field}")
+    return ids
+
+def _parse_claim(data: Any) -> FindingClaimSnapshot:
+    if not isinstance(data, dict): raise FindingValidationError("source claim must be an object")
+    if set(data) != {"classification","subject","statement","confidence","suggested_severity","evidence_ids"}: raise FindingValidationError("source claim fields are invalid")
+    if data["classification"] != SOURCE_CLASSIFICATION: raise FindingValidationError("source claim classification must be finding_candidate")
+    conf=_nonempty(data["confidence"], "source claim confidence")
+    sev=data["suggested_severity"]
+    if sev is not None and sev not in SEVERITIES: raise FindingValidationError("unsupported source suggested_severity")
+    return FindingClaimSnapshot(SOURCE_CLASSIFICATION, _nonempty(data["subject"], "subject"), _nonempty(data["statement"], "statement"), conf, sev, _unique_uuid_list(data["evidence_ids"], "evidence_ids"))
+
+def _parse_source(data: Any) -> FindingSource:
+    if not isinstance(data, dict): raise FindingValidationError("source must be an object")
+    if set(data) != {"result_id","request_id","skill","result_path","result_sha256","claim_id","claim"}: raise FindingValidationError("source fields are invalid")
+    path=normalize_result_path(data["result_path"])
+    sha=data["result_sha256"]
+    if not isinstance(sha, str) or not _SHA256.fullmatch(sha): raise FindingValidationError("result_sha256 must contain 64 lowercase hexadecimal characters")
+    return FindingSource(_uuid4(data["result_id"], "result_id"), _uuid4(data["request_id"], "request_id"), _nonempty(data["skill"], "skill"), path, sha, _uuid4(data["claim_id"], "claim_id"), _parse_claim(data["claim"]))
+
+def _parse_record(data: Any, run_id: str, expected_sequence: int, event_ids: set[str], finding_ids: set[str], pairs: set[tuple[str,str]]) -> FindingRecord:
+    required={"schema_version","sequence","event_type","event_id","finding_id","run_id","promoted_at","promoted_by","classification","title","affected_candidate","candidate_type","location","severity","confidence","validation_basis","validation_reason","impact","remediation","source","evidence_ids","notes"}
+    if not isinstance(data, dict): raise FindingValidationError("finding record must be a JSON object")
+    if set(data) != required: raise FindingValidationError("finding record fields must exactly match required fields")
+    if data["schema_version"] != SCHEMA_VERSION: raise FindingValidationError("unsupported finding schema_version")
+    if data["sequence"] != expected_sequence: raise FindingValidationError("finding sequence must increment by exactly one")
+    if data["event_type"] != EVENT_TYPE: raise FindingValidationError("unknown finding event_type")
+    event_id=_uuid4(data["event_id"], "event_id"); finding_id=_uuid4(data["finding_id"], "finding_id")
+    if event_id in event_ids: raise FindingValidationError("duplicate finding event_id")
+    if finding_id in finding_ids: raise FindingValidationError("duplicate finding_id")
+    event_ids.add(event_id); finding_ids.add(finding_id)
+    if data["run_id"] != run_id: raise FindingValidationError("finding run_id does not match manifest")
+    if data["classification"] != CLASSIFICATION: raise FindingValidationError("classification must be validated_finding")
+    sev=data["severity"]; conf=data["confidence"]; basis=data["validation_basis"]
+    if sev not in SEVERITIES: raise FindingValidationError("unsupported severity")
+    if conf not in PROMOTED_CONFIDENCES: raise FindingValidationError("unsupported promoted finding confidence")
+    if basis not in VALIDATION_BASES: raise FindingValidationError("unsupported validation_basis")
+    source=_parse_source(data["source"]); pair=(source.result_id, source.claim_id)
+    if pair in pairs: raise FindingValidationError("duplicate source result_id and claim_id")
+    pairs.add(pair)
+    evidence_ids=_unique_uuid_list(data["evidence_ids"], "evidence_ids")
+    if not set(source.claim.evidence_ids).issubset(set(evidence_ids)): raise FindingValidationError("finding evidence_ids must include all source claim evidence IDs")
+    return FindingRecord(SCHEMA_VERSION, data["sequence"], EVENT_TYPE, event_id, finding_id, run_id, _timestamp(data["promoted_at"]), _nonempty(data["promoted_by"], "promoted_by"), CLASSIFICATION, _nonempty(data["title"], "title"), _nonempty(data["affected_candidate"], "affected_candidate"), _nonempty(data["candidate_type"], "candidate_type"), _optional(data["location"], "location"), sev, conf, basis, _nonempty(data["validation_reason"], "validation_reason"), _nonempty(data["impact"], "impact"), _nonempty(data["remediation"], "remediation"), source, evidence_ids, _optional(data["notes"], "notes"))
+
+def load_finding_registry(run_dir: str | Path) -> FindingRegistrySummary:
+    manifest=load_manifest(run_dir); path=Path(run_dir)/REGISTRY
+    if not path.exists(): return FindingRegistrySummary(manifest.run_id, 0, ())
+    records=[]; event_ids=set(); finding_ids=set(); pairs=set(); seen=False
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if raw == "":
+            if seen: raise FindingValidationError(f"blank line in finding registry at line {lineno}")
+            continue
+        seen=True
+        try: data=json.loads(raw)
+        except json.JSONDecodeError as exc: raise FindingValidationError(f"malformed JSON in finding registry at line {lineno}: {exc}") from exc
+        records.append(_parse_record(data, manifest.run_id, len(records)+1, event_ids, finding_ids, pairs))
+    return FindingRegistrySummary(manifest.run_id, len(records), tuple(records))
+
+def ensure_finding_registry(run_dir: str | Path) -> None:
+    load_manifest(run_dir); load_state(run_dir)
+    (Path(run_dir)/REGISTRY).touch(exist_ok=True)
+
+def normalize_result_path(path_value: Any) -> str:
+    text=_nonempty(path_value, "result_path").replace("\\", "/")
+    p=PurePosixPath(text)
+    if p.is_absolute() or any(part in {"", ".", ".."} for part in p.parts): raise FindingValidationError("result_path must be a canonical relative POSIX path")
+    if len(p.parts) != 3 or p.parts[0] != "contracts" or p.parts[1] != "results": raise FindingValidationError("result_path must be beneath contracts/results/")
+    return p.as_posix()
+
+def validate_source_result_path(run_dir: str | Path, result_file: str | Path) -> tuple[str, Path]:
+    run=Path(run_dir).resolve(); base=run/"contracts"/"results"; raw=Path(result_file)
+    if raw.is_absolute():
+        p=raw
+    else:
+        s=raw.as_posix()
+        p=(Path.cwd()/raw) if s.startswith(str(Path(run_dir).as_posix())) or s.startswith("/") else (run/raw)
+    try: resolved=p.resolve(strict=False); rel=resolved.relative_to(base.resolve(strict=False))
+    except ValueError as exc: raise FindingValidationError("source result must be beneath contracts/results/") from exc
+    if any(part in {"", ".", ".."} for part in rel.parts): raise FindingValidationError("unsafe result path")
+    full=base.joinpath(*rel.parts)
+    current=run
+    for part in (Path("contracts")/"results"/rel).parts:
+        current=current/part
+        try: st=os.lstat(current)
+        except FileNotFoundError as exc: raise FindingValidationError("source result is missing") from exc
+        if stat.S_ISLNK(st.st_mode): raise FindingValidationError("source result path contains a symbolic link")
+    if full.is_dir(): raise FindingValidationError("source result must be a file")
+    if not full.is_file(): raise FindingValidationError("source result must be a regular file")
+    return (PurePosixPath("contracts/results")/PurePosixPath(*rel.parts)).as_posix(), full
+
+def _hash_file(path: Path) -> str:
+    h=hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+def _verify_ids(run_dir: Path, ids: list[str]) -> None:
+    registry=load_evidence_registry(run_dir); known={r.evidence_id for r in registry.records}
+    for eid in ids:
+        if eid not in known: raise FindingPromotionRefusal(f"unknown evidence_id: {eid}")
+    checks={v.evidence_id: v for v in verify_all_evidence(run_dir)}
+    for eid in ids:
+        status=checks[eid].status if eid in checks else "missing"
+        if status != "verified": raise FindingPromotionRefusal(f"evidence {eid} verification {status}")
+
+def _claim_snapshot(claim: dict[str, Any]) -> FindingClaimSnapshot:
+    return FindingClaimSnapshot(claim["classification"], claim["subject"], claim["statement"], claim["confidence"], claim.get("suggested_severity"), list(claim["evidence_ids"]))
+
+def promote_finding(run_dir: str | Path, result_file: str | Path, claim_id: str, *, actor: str, title: str, candidate: str, severity: str, confidence: str, validation_basis: str, validation_reason: str, impact: str, remediation: str, location: str | None=None, notes: str | None=None, supplementary_evidence_ids: list[str] | None=None) -> FindingRecord:
+    run=Path(run_dir); manifest=load_manifest(run); state=load_state(run)
+    if state.current_state not in PROMOTION_STATES: raise FindingPromotionRefusal(f"finding promotion is not permitted while run is {state.current_state}")
+    registry=load_finding_registry(run); ensure_finding_registry(run)
+    actor=_nonempty(actor,"actor"); title=_nonempty(title,"title"); validation_reason=_nonempty(validation_reason,"validation_reason"); impact=_nonempty(impact,"impact"); remediation=_nonempty(remediation,"remediation"); location=_optional(location,"location"); notes=_optional(notes,"notes")
+    if severity not in SEVERITIES: raise FindingValidationError("unsupported severity")
+    if confidence not in PROMOTED_CONFIDENCES: raise FindingPromotionRefusal("low confidence findings cannot be promoted")
+    if validation_basis not in VALIDATION_BASES: raise FindingValidationError("unsupported validation_basis")
+    cid=_uuid4(claim_id,"claim_id")
+    rel, full=validate_source_result_path(run, result_file)
+    report=validate_skill_result(run, full)
+    if not report.structural_valid: raise FindingValidationError("source result contract is invalid: "+"; ".join(report.errors))
+    if report.overall_status != "valid": raise FindingPromotionRefusal("source result evidence does not verify: "+"; ".join(report.errors))
+    result=load_skill_result(run, full)
+    if result.status not in {"completed", "partial"}: raise FindingPromotionRefusal("blocked or failed results cannot be promoted")
+    req=load_skill_request(run, run/"contracts"/"requests"/f"{result.request_id}.json")
+    if req.request_id != result.request_id or req.run_id != result.run_id or req.skill != result.skill: raise FindingValidationError("result does not match linked request")
+    claim=next((c for c in result.claims if c["claim_id"] == cid), None)
+    if claim is None: raise FindingPromotionRefusal("selected claim_id was not found")
+    if claim["classification"] != SOURCE_CLASSIFICATION: raise FindingPromotionRefusal("only finding_candidate claims can be promoted")
+    if any(r.source.result_id == result.result_id and r.source.claim_id == cid for r in registry.records): raise FindingPromotionRefusal("source claim has already been promoted")
+    evidence_ids=list(dict.fromkeys(list(claim["evidence_ids"]) + list(supplementary_evidence_ids or [])))
+    evidence_ids=_unique_uuid_list(evidence_ids, "evidence_ids")
+    _verify_ids(run, evidence_ids)
+    decision=evaluate_scope_path(run, candidate)
+    if decision.decision == "error": raise FindingValidationError(decision.reason)
+    if decision.decision != "allow": raise FindingPromotionRefusal(decision.reason)
+    sha=_hash_file(full)
+    record=FindingRecord(SCHEMA_VERSION, registry.finding_count+1, EVENT_TYPE, str(uuid4()), str(uuid4()), manifest.run_id, utc_now(), actor, CLASSIFICATION, title, decision.normalized_candidate or candidate, decision.candidate_type or "domain", location, severity, confidence, validation_basis, validation_reason, impact, remediation, FindingSource(result.result_id, result.request_id, result.skill, rel, sha, cid, _claim_snapshot(claim)), evidence_ids, notes)
+    with (run/REGISTRY).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record.to_dict(), sort_keys=True)+"\n"); handle.flush(); os.fsync(handle.fileno())
+    return record
+
+def list_findings(run_dir: str | Path) -> FindingRegistrySummary: load_state(run_dir); return load_finding_registry(run_dir)
+
+def get_finding(run_dir: str | Path, finding_id: str) -> FindingRecord | None:
+    fid=_uuid4(finding_id,"finding_id")
+    for r in list_findings(run_dir).records:
+        if r.finding_id == fid: return r
+    return None
+
+def _verify_evidence_for_record(run_dir: Path, ids: list[str]) -> tuple[str, str]:
+    try:
+        reg=load_evidence_registry(run_dir); known={r.evidence_id for r in reg.records}; checks={v.evidence_id: v for v in verify_all_evidence(run_dir)}
+        for eid in ids:
+            if eid not in known: return "evidence_missing", f"evidence {eid} is not registered"
+            status=checks[eid].status
+            if status == "missing": return "evidence_missing", f"evidence {eid} is missing"
+            if status == "mismatch": return "evidence_mismatch", f"evidence {eid} does not match registry"
+            if status != "verified": return "evidence_unsafe", f"evidence {eid} is unsafe: {checks[eid].reason}"
+        return "verified", "evidence artifacts verify"
+    except (EvidenceValidationError, StateValidationError) as exc:
+        return "invalid", str(exc)
+
+def verify_finding(run_dir: str | Path, finding: FindingRecord) -> FindingVerification:
+    run=Path(run_dir); actual=None; source_status="verified"; reason=[]
+    try:
+        rel, full=validate_source_result_path(run, run/finding.source.result_path)
+        actual=_hash_file(full)
+        if actual != finding.source.result_sha256:
+            source_status="source_changed"; reason.append("source result SHA-256 changed")
+        else:
+            res=load_skill_result(run, full)
+            if res.result_id != finding.source.result_id: source_status="source_changed"; reason.append("source result_id changed")
+            claim=next((c for c in res.claims if c["claim_id"] == finding.source.claim_id), None)
+            if claim is None or _claim_snapshot(claim).to_dict() != finding.source.claim.to_dict(): source_status="source_changed"; reason.append("source claim snapshot changed")
+    except FindingValidationError as exc:
+        source_status="source_missing" if "missing" in str(exc) else "invalid"; reason.append(str(exc))
+    except SkillContractValidationError as exc:
+        source_status="source_changed"; reason.append(str(exc))
+    evidence_status, ev_reason=_verify_evidence_for_record(run, finding.evidence_ids)
+    if evidence_status != "verified": reason.append(ev_reason)
+    dec=evaluate_scope_path(run, finding.affected_candidate)
+    scope_status="currently_in_scope" if dec.decision == "allow" else "currently_out_of_scope" if dec.decision == "deny" else "scope_error"
+    if source_status == "verified" and evidence_status == "verified": overall="verified"
+    elif source_status != "verified": overall=source_status
+    else: overall=evidence_status
+    return FindingVerification(finding.finding_id, finding.title, source_status, finding.source.result_sha256, actual, evidence_status, scope_status, overall, "; ".join(reason) if reason else "finding provenance and evidence verify")
+
+def verify_all_findings(run_dir: str | Path, finding_id: str | None=None) -> list[FindingVerification]:
+    summary=list_findings(run_dir)
+    records=list(summary.records)
+    if finding_id is not None:
+        fid=_uuid4(finding_id,"finding_id"); records=[r for r in records if r.finding_id == fid]
+        if not records: return [FindingVerification(fid, "", "invalid", "", None, "invalid", "scope_error", "invalid", "finding_id is not registered")]
+    return [verify_finding(run_dir, r) for r in records]

--- a/skills/_shared/run-contract.md
+++ b/skills/_shared/run-contract.md
@@ -9,3 +9,9 @@ Treat discoveries as observations that do not expand scope. Save useful raw outp
 Return only supported result classifications: `observation`, `exposure`, `hypothesis`, and `finding_candidate`. Use `finding_candidate` rather than `validated_finding`; it is not a validated finding. Return `blocked` when state, scope, approval, or required evidence prevents safe completion.
 
 Recommend `intrusive_validation` only as a separate human-reviewed handoff. Never recommend prohibited actions. Do not execute recommended actions during result formatting. Produce structured `skill_result` version 1 JSON under `contracts/results/`.
+
+## Finding promotion boundary
+
+Skills may classify supported claims as `observation`, `exposure`, `hypothesis`, or `finding_candidate` only. Skills must never emit `validated_finding`, `confirmed_vulnerability`, `exploited`, or `compromised`; only the Python `outrider finding promote` workflow may create a `validated_finding` after human review, registered evidence verification, current deterministic scope validation, and permitted workflow state checks.
+
+Recommendations in a skill result are handoff suggestions, not findings. Claim confidence and `suggested_severity` remain advisory; the human reviewer must explicitly choose final promoted-finding severity and confidence. `findings.jsonl` is append-only and is the deterministic source for promoted findings. Skills must not modify `findings.jsonl` or `findings.md`. No skill may claim exploitation or compromise without a separate authorized workflow outside this feature.

--- a/skills/analysis-and-reporting/SKILL.md
+++ b/skills/analysis-and-reporting/SKILL.md
@@ -394,3 +394,7 @@ Follow the shared run-contract instructions in `../_shared/run-contract.md`.
 - Do not claim final finding validation; use `finding_candidate` only when a human-reviewed candidate should be handed off.
 - Do not directly edit `manifest.json`, `scope.yaml`, `run.jsonl`, `evidence.jsonl`, or `approvals.jsonl`.
 - Use policy-gated MCP with the explicit `run_dir`; the Python control layer and MCP boundary must reevaluate current controls.
+
+## Finding promotion boundary
+
+Analysis may classify evidence-backed claims as `finding_candidate` and may recommend a severity, but it must not finalize severity, create `validated_finding`, or self-promote a claim. Human promotion occurs only through `outrider finding promote` after the Python control layer verifies the source contract, registered evidence, current scope, and workflow state.

--- a/skills/report-template/SKILL.md
+++ b/skills/report-template/SKILL.md
@@ -146,3 +146,7 @@ Follow the shared run-contract instructions in `../_shared/run-contract.md`.
 - Do not claim final finding validation; use `finding_candidate` only when a human-reviewed candidate should be handed off.
 - Do not directly edit `manifest.json`, `scope.yaml`, `run.jsonl`, `evidence.jsonl`, or `approvals.jsonl`.
 - Use policy-gated MCP with the explicit `run_dir`; the Python control layer and MCP boundary must reevaluate current controls.
+
+## Promoted finding source
+
+Promoted findings are read from the append-only `findings.jsonl` registry. Unpromoted `finding_candidate` claims from skill results must be clearly labeled as candidates, and report generation must not silently promote them. In this PR, `findings.md` remains operator-managed working Markdown rather than an automatically rendered finding export.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ class CliCommandTests(unittest.TestCase):
         "run.jsonl",
         "evidence.jsonl",
         "approvals.jsonl",
+        "findings.jsonl",
         "artifacts",
         "contracts",
         "contracts/requests",

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+import hashlib, json, tempfile, unittest
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from outrider.cli import init_run
+from outrider.evidence import register_evidence
+from outrider.finding import *
+from outrider.skill_contract import create_skill_request, utc_now, validate_skill_result
+from outrider.state import load_manifest, load_state, transition_state
+
+class Args: pass
+
+def make_run(td, scope=None):
+    a=Args(); a.target='example.com'; a.output_dir=str(td); a.scope=scope or ['example.com','*.example.com']; a.exclude=[]; a.actor='authorized-operator'; a.authorization_reference='EXAMPLE-ROE-001'; init_run(a)
+    return Path(td)/'example.com'
+
+def ready_run(td):
+    run=make_run(td); transition_state(run,'scoped','authorized-operator'); transition_state(run,'collecting','authorized-operator'); transition_state(run,'analyzing','authorized-operator'); return run
+
+def make_source(run, classification='finding_candidate', status='completed', candidate='api.example.com'):
+    req,path,_=create_skill_request(run,'recon-asset-discovery','authorized-operator','review','public_source_lookup','example.com')
+    art=run/'artifacts'/f'evidence-{uuid4()}.txt'; art.write_text('OpenAPI schema at api.example.com', encoding='utf-8')
+    ev=register_evidence(run,art.relative_to(run).as_posix(),'authorized-operator','text')
+    claim_id=str(uuid4())
+    result={"schema_version":1,"contract_type":"skill_result","result_id":str(uuid4()),"request_id":req.request_id,"run_id":req.run_id,"skill":req.skill,"completed_at":utc_now(),"status":status,"summary":"candidate","claims":[{"claim_id":claim_id,"classification":classification,"subject":candidate+"/openapi.json","statement":"The endpoint returns an OpenAPI schema without authentication.","confidence":"high","suggested_severity":"medium","evidence_ids":[ev.evidence_id]}],"discovered_candidates":[],"recommended_actions":[],"errors":[] if status in {'completed','partial'} else [{"code":"blocked","message":"blocked"}]}
+    rp=run/'contracts/results'/f'{result["result_id"]}.json'; rp.write_text(json.dumps(result, sort_keys=True), encoding='utf-8')
+    return req, rp, claim_id, ev, result
+
+def promote(run, rp, claim_id, **kw):
+    args=dict(actor='authorized-operator',title='Public OpenAPI schema exposes internal API structure',candidate='api.example.com',severity='medium',confidence='high',validation_basis='response_evidence',validation_reason='The registered response contains a valid OpenAPI schema.',impact='The schema exposes undocumented API routes and object structures.',remediation='Restrict schema access and remove unnecessary production documentation.',location='/openapi.json')
+    args.update(kw)
+    return promote_finding(run, rp, claim_id, **args)
+
+class FindingTests(unittest.TestCase):
+    def test_init_creates_empty_findings_and_rerun_preserves_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            run=make_run(td); manifest=load_manifest(run).run_id
+            self.assertTrue((run/'findings.jsonl').exists()); self.assertEqual((run/'findings.jsonl').read_text(),'')
+            (run/'findings.jsonl').write_text('{"keep":true}\n')
+            before={rel:(run/rel).read_text() for rel in ['run.jsonl','evidence.jsonl','approvals.jsonl','findings.md']}
+            make_run(td)
+            self.assertEqual(load_manifest(run).run_id, manifest)
+            self.assertEqual((run/'findings.jsonl').read_text(),'{"keep":true}\n')
+            for rel,text in before.items(): self.assertEqual((run/rel).read_text(), text)
+            (run/'findings.jsonl').unlink(); make_run(td)
+            self.assertTrue((run/'findings.jsonl').exists()); self.assertEqual(load_state(run).event_count,1)
+
+    def test_promote_success_duplicate_and_verify_changes(self):
+        with tempfile.TemporaryDirectory() as td:
+            run=ready_run(td); req,rp,cid,ev,result=make_source(run)
+            before={rel:(run/rel).read_bytes() for rel in ['manifest.json','scope.yaml','run.jsonl','evidence.jsonl','approvals.jsonl','findings.md',f'contracts/requests/{req.request_id}.json',f'contracts/results/{result["result_id"]}.json',ev.path]}
+            rec=promote(run,rp,cid)
+            self.assertEqual(rec.classification,'validated_finding')
+            self.assertEqual(rec.source.claim.classification,'finding_candidate')
+            self.assertEqual(rec.source.result_sha256, hashlib.sha256(rp.read_bytes()).hexdigest())
+            self.assertEqual(rec.source.result_path, f'contracts/results/{result["result_id"]}.json')
+            self.assertEqual(rec.evidence_ids,[ev.evidence_id])
+            self.assertEqual(load_finding_registry(run).finding_count,1)
+            for rel,data in before.items(): self.assertEqual((run/rel).read_bytes(), data, rel)
+            with self.assertRaises(FindingPromotionRefusal): promote(run,rp,cid,title='Changed')
+            self.assertEqual(load_finding_registry(run).finding_count,1)
+            ver=verify_all_findings(run)[0]; self.assertEqual(ver.overall_status,'verified'); self.assertEqual(ver.current_scope_status,'currently_in_scope')
+            rp.write_text(json.dumps({**result,'summary':'changed'}, sort_keys=True)); self.assertEqual(verify_all_findings(run)[0].overall_status,'source_changed')
+            rp.write_text(json.dumps(result, sort_keys=True)); (run/ev.path).write_text('changed')
+            self.assertEqual(verify_all_findings(run)[0].overall_status,'evidence_mismatch')
+            (run/ev.path).write_text('OpenAPI schema at api.example.com')
+            self.assertEqual(verify_all_findings(run)[0].overall_status,'verified')
+            (run/'scope.yaml').write_text((run/'scope.yaml').read_text().replace('out_of_scope: []','out_of_scope:\n  - "api.example.com"'))
+            self.assertEqual(verify_all_findings(run)[0].current_scope_status,'currently_out_of_scope')
+            self.assertEqual(load_finding_registry(run).finding_count,1)
+
+    def test_refusals_and_validation_errors_append_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            run=ready_run(td); req,rp,cid,ev,result=make_source(run)
+            with self.assertRaises(FindingPromotionRefusal): promote(run,rp,cid,candidate='outside.example')
+            with self.assertRaises(FindingPromotionRefusal): promote(run,rp,cid,confidence='low')
+            bad_req,bad_rp,bad_cid,_,_=make_source(run,'observation')
+            with self.assertRaises(FindingPromotionRefusal): promote(run,bad_rp,bad_cid)
+            blocked_req,blocked_rp,blocked_cid,_,_=make_source(run,'finding_candidate','blocked')
+            self.assertEqual(validate_skill_result(run, blocked_rp).overall_status, 'valid')
+            with self.assertRaises(FindingPromotionRefusal): promote(run,blocked_rp,blocked_cid)
+            bad=dict(result); bad['claims'][0]['classification']='validated_finding'; rp.write_text(json.dumps(bad))
+            with self.assertRaises(FindingValidationError): promote(run,rp,cid)
+            with self.assertRaises(FindingValidationError): promote(run,'/etc/passwd',cid)
+            self.assertEqual(load_finding_registry(run).finding_count,0)
+
+    def test_registry_validation_and_schema_constants(self):
+        with tempfile.TemporaryDirectory() as td:
+            run=ready_run(td); _,rp,cid,ev,_=make_source(run); rec=promote(run,rp,cid)
+            data=rec.to_dict(); path=run/'findings.jsonl'
+            self.assertEqual(UUID(data['event_id']).version,4); self.assertEqual(UUID(data['finding_id']).version,4)
+            variants=[('sequence',2),('event_type','bad'),('classification','finding_candidate'),('severity','bad'),('confidence','low'),('validation_basis','bad')]
+            for key,val in variants:
+                bad=dict(data); bad[key]=val; path.write_text(json.dumps(bad)+'\n')
+                with self.assertRaises(FindingValidationError): load_finding_registry(run)
+            bad=dict(data); bad['extra']=1; path.write_text(json.dumps(bad)+'\n')
+            with self.assertRaises(FindingValidationError): load_finding_registry(run)
+            path.write_text(json.dumps(data)+'\n\n')
+            with self.assertRaises(FindingValidationError): load_finding_registry(run)
+            path.write_text('[]\n')
+            with self.assertRaises(FindingValidationError): load_finding_registry(run)
+            schema=json.loads((Path(__file__).resolve().parents[1]/'contracts/finding-v1.schema.json').read_text())
+            self.assertEqual(set(schema['properties']['severity']['enum']), set(SEVERITIES))
+            self.assertEqual(set(schema['properties']['confidence']['enum']), set(PROMOTED_CONFIDENCES))
+            self.assertEqual(set(schema['properties']['validation_basis']['enum']), set(VALIDATION_BASES))
+            self.assertEqual(schema['properties']['classification']['const'], CLASSIFICATION)
+            self.assertEqual(schema['properties']['event_type']['const'], EVENT_TYPE)
+            self.assertFalse(schema['additionalProperties'])
+            self.assertFalse(schema['properties']['source']['additionalProperties'])
+            self.assertFalse(schema['properties']['source']['properties']['claim']['additionalProperties'])
+
+if __name__=='__main__': unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a deterministic, evidence-backed Python workflow to promote skill-produced `finding_candidate` claims into human-reviewed `validated_finding` records while preventing skills from self-certifying findings.
- Ensure promoted findings carry verifiable provenance (source result path and streaming SHA-256), include required reviewer metadata, require current-scope and permitted workflow-state checks, and depend on locally verified evidence artifacts.

### Description
- Added `outrider/finding.py` implementing typed structures, registry loading/validation (`findings.jsonl`), `promote_finding`, listing, showing, and verification flows, streaming SHA-256 hashing, source-result path safety checks, claim snapshot storage, duplicate source-claim detection, and read-only verification that reports source/evidence/scope status.
- Extended `outrider/cli.py` with `finding promote|list|show|verify` subcommands, human and JSON outputs, init now creates `findings.jsonl` (append-only), and CLI error codes following the specification.
- Added `contracts/finding-v1.schema.json` documenting the finding record shape and updated `contracts/README.md`, `skills/_shared/run-contract.md`, `skills/analysis-and-reporting/SKILL.md`, `skills/report-template/SKILL.md`, `README.md`, `docs/architecture.md`, and ADR `docs/adr/0006-deterministic-finding-promotion.md` to document boundaries and behavior.
- Added tests `tests/test_finding.py` and updated `tests/test_cli.py` to cover init behavior, promotion success, refusal paths, duplicate prevention, registry validation, source/evidence verification changes, and schema/constants drift; preserved all existing deterministic modules and avoided introducing MCP, HTTP, DNS, or execution behavior.

### Testing
- Ran the full test suite with `python -m unittest discover -s tests -p "test_*.py"` (72 tests) and all tests passed.
- Ran `python -m compileall outrider tests mcp-server` and `python -m pip check`, both succeeded, and `python -m json.tool contracts/finding-v1.schema.json` validated the schema.
- Attempted `python -m pip install -e .` but build-dependency installation failed due to the environment package-index tunnel returning `403` for `setuptools>=68`; this is an environment network restriction and not a project dependency change.

Interpreter used: `/root/.pyenv/versions/3.12.13/bin/python`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53eca6d2a883309fc088bf65682201)