### PR TITLE
release: prepare Python 0.2.0 and plugin 3.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "outrider-recon",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Claude-native authorized external recon and ASM methodology bundle with 90 documented capabilities across 11 skills, plus deterministic Python controls for run state, scope, evidence, approvals, skill contracts, finding promotion, optional guarded MCP enrichment, and optional local read-only web review. It does not provide unrestricted autonomous exploitation.",
   "author": {
     "name": "Ap6pack",

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,93 @@
+name: Unsigned release candidates
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-candidates:
+    name: Build unsigned release candidates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out selected commit
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+      - name: Install local package with web extras
+        run: python -m pip install -e ".[web]"
+      - name: Run release audit
+        run: python tools/release_audit.py
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -p "test_*.py"
+      - name: Compile Python sources
+        run: python -m compileall outrider tests mcp-server tools
+      - name: Remove old build output safely
+        run: rm -rf dist build *.egg-info
+      - name: Build wheel and source distribution
+        run: python -m build
+      - name: Check Python distributions
+        run: python -m twine check dist/*
+      - name: Build deterministic plugin/content bundle
+        run: python tools/build_release_bundle.py --output-dir dist --source-date-epoch 1783900800
+      - name: Generate SHA256SUMS
+        run: |
+          cd dist
+          sha256sum outrider_recon-0.2.0-py3-none-any.whl outrider_recon-0.2.0.tar.gz outrider-recon-bundle-3.0.1.zip | sort -k2 > SHA256SUMS
+          sha256sum -c SHA256SUMS
+      - name: Inspect archive contents
+        run: |
+          python -m zipfile -l dist/outrider-recon-bundle-3.0.1.zip
+          python - <<'PY'
+          import zipfile
+          names=zipfile.ZipFile('dist/outrider-recon-bundle-3.0.1.zip').namelist()
+          assert not any('/tests/' in n or '/.github/' in n or '__pycache__' in n for n in names)
+          PY
+      - name: Verify artifact version names
+        run: |
+          test -f dist/outrider_recon-0.2.0-py3-none-any.whl
+          test -f dist/outrider_recon-0.2.0.tar.gz
+          test -f dist/outrider-recon-bundle-3.0.1.zip
+      - name: Clean base install smoke
+        run: |
+          python -m venv /tmp/outrider-base
+          /tmp/outrider-base/bin/python -m pip install dist/outrider_recon-0.2.0-py3-none-any.whl
+          /tmp/outrider-base/bin/outrider --version | grep '0.2.0'
+          /tmp/outrider-base/bin/python -m outrider --version | grep '0.2.0'
+      - name: Clean web install smoke
+        run: |
+          python -m venv /tmp/outrider-web
+          /tmp/outrider-web/bin/python -m pip install "dist/outrider_recon-0.2.0-py3-none-any.whl[web]"
+          /tmp/outrider-web/bin/python - <<'PY'
+          from fastapi.testclient import TestClient
+          from outrider.web_app import create_app
+          c=TestClient(create_app())
+          assert c.get('/').status_code in (200, 404)
+          PY
+      - name: Verify bundle manifest
+        run: |
+          python - <<'PY'
+          import json, zipfile
+          with zipfile.ZipFile('dist/outrider-recon-bundle-3.0.1.zip') as z:
+              m=json.loads(z.read('outrider-recon-bundle-3.0.1/RELEASE-MANIFEST.json'))
+          assert m['python_version']=='0.2.0'
+          assert m['plugin_version']=='3.0.1'
+          assert m['skill_count']==11
+          PY
+      - name: Upload unsigned candidates
+        uses: actions/upload-artifact@v4
+        with:
+          name: outrider-release-candidates-python-0.2.0-plugin-3.0.1
+          path: |
+            dist/outrider_recon-0.2.0-py3-none-any.whl
+            dist/outrider_recon-0.2.0.tar.gz
+            dist/outrider-recon-bundle-3.0.1.zip
+            dist/SHA256SUMS
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,38 +9,57 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Added deterministic release-readiness audit tooling, package-build and clean-install validation, installed skill-catalog validation, schema and web-resource packaging validation, and documentation/metadata corrections without a release, tag, publication, or version change.
+No unreleased changes.
 
-- Added an optional local loopback-only, read-only web review plane with a dashboard and run detail views for scope, state, evidence, approvals, contracts, findings, and integrity summaries; it serves no artifacts and performs no run mutations.
+---
+
+## [Python 0.2.0] -- 2026-07-13
+
+### Added
+
+- Added deterministic scope checks with exact-domain, wildcard-subdomain, exact-IP, CIDR, out-of-scope precedence, default-deny decisions, and the offline `outrider scope-check` CLI.
+- Added stable UUID-backed run manifests, durable workflow state, append-only schema-versioned state events, validated workflow transitions, and legacy-run bootstrap commands.
+- Added an evidence registry with SHA-256 and size recording, local artifact verification, path containment, symlink protections, and `outrider evidence` CLI commands.
+- Added approval records, time-bounded grants, revocations, derived approval status, action-policy decisions, permanently prohibited action categories, and `outrider approval` / `outrider action-check` CLI commands.
+- Added MCP guard integration for fixed action mappings, pre-request scope/state/approval checks, exact active DNS approval enforcement, structured policy envelopes, and zero network or DNS activity for denied calls.
+- Added structured skill request/result contracts, a packaged skill catalog, packaged schemas, and deterministic finding promotion from `finding_candidate` records to evidence-backed findings.
+- Added an optional local loopback-only, read-only web review plane with packaged web resources for scope, state, evidence, approvals, contracts, findings, and integrity summaries.
+- Added clean-install validation, release-readiness tooling, package-build checks, CLI `--version`, and `python -m outrider` support.
+
+### Changed
+
+- Prepared the Python package as `0.2.0`, a minor pre-1.0 release for substantial backward-compatible control-plane functionality; this does not claim API stability beyond pre-1.0 expectations.
+- Kept MCP as an optional source-checkout companion and kept web dependencies in optional extras rather than base runtime dependencies.
+- Updated CI and packaging validation to install declared dependencies before compiling and running the complete unittest suite.
+
+### Fixed
 
 - Restored append-only approval records and bounded action-policy evaluation after the approval-layer revert.
 - Reconciled MCP tool-boundary enforcement with the restored approval layer and exact active DNS approval checks.
 - Restored approval and MCP regression coverage for policy decisions, CLI exits, and denied zero-network paths.
-- Updated CI to install declared Python dependencies before compiling and running the complete unittest suite.
 
-### Added
+### Security
 
-- Enforce explicit MCP run context with fixed action mappings, pre-request scope/state/approval policy checks, exact DNS approval enforcement, structured policy response envelopes, and zero network or DNS activity for denied calls.
-
-- Time-bounded approval grants, append-only revocations, derived approval status, scope/state/approval action-policy checks, permanently prohibited action categories, and `outrider approval` / `outrider action-check` CLI commands.
-
-- Append-only evidence registration, SHA-256 and size recording, local artifact verification, artifact path-containment and symlink protections, and `outrider evidence` CLI commands.
-
-- Stable UUID-backed run manifests, append-only schema-versioned workflow state events, validated workflow transitions, and explicit legacy-run bootstrap commands.
-
-- Add deterministic scope-file validation with exact-domain, wildcard-subdomain, exact-IP, and CIDR matching.
-- Add out-of-scope precedence, default-deny scope decisions, and the offline `outrider scope-check` CLI command.
-
-### Fixed
-
-- Repair Markdown lint by using a real configuration file, update the action for Node 24, format Markdown content for lint, and update installer skill counting to avoid `ls` while passing ShellCheck.
+- Enforced deterministic no-network denial paths for out-of-scope or unapproved MCP requests and preserved local artifact integrity checks.
 
 ### Documentation
 
-- Add automated CLI tests and pull-request CI coverage.
-- Clarify implementation status across Claude skills, Python CLI scaffolding, optional MCP enrichment, and the planned web UI control/review plane.
-- Document separate version domains for the plugin/content release, Python CLI package, individual skill frontmatter, and MCP server implementation.
-- Reconcile stale installation and security-policy references to older plugin/content release lines without creating a new numbered release.
+- Documented separate Python, plugin/content, skill-frontmatter, schema, and MCP version domains.
+- Clarified implementation status across Claude skills, Python CLI controls, optional MCP enrichment, optional web review, packaging resources, and release-readiness limitations.
+
+---
+
+## [Claude plugin/content 3.0.1] -- 2026-07-13
+
+### Changed
+
+- Prepared the Claude plugin/content bundle as `3.0.1`, a patch release because the existing 3.0 methodology and capability set remain unchanged.
+- Corrected plugin metadata and documentation so they accurately describe deterministic Python controls, guarded MCP enrichment, and the local read-only web plane.
+- Clarified skill/Python/MCP/web responsibility boundaries, shared structured-run contract guidance, discovery-does-not-expand-scope guidance, and the `finding_candidate` versus `validated_finding` boundary.
+
+### Documentation
+
+- Corrected installation, security, architecture, and release-readiness wording without changing individual skill methodology, individual skill frontmatter versions, or capability count.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,22 @@ Outrider is not another subdomain-enum wrapper. It is an agentic recon workflow 
 
 ## Version domains and installation boundaries
 
-Outrider uses independent version domains. The Python package remains `0.1.0`; the Claude plugin/content bundle remains `3.0.0`; each skill keeps its own frontmatter version; and JSON contract schemas currently use schema version `1`. Do not assume the Python package version and Claude plugin/content version move together.
+Outrider uses independent version domains. The Python package remains `0.2.0`; the Claude plugin/content bundle remains `3.0.1`; each skill keeps its own frontmatter version; and JSON contract schemas currently use schema version `1`. Do not assume the Python package version and Claude plugin/content version move together.
 
 The base Python package installs the deterministic local controls and CLI with PyYAML only. Web review support is optional via the `web` extra, and MCP server dependencies are installed separately from `mcp-server/requirements.txt` in a source checkout.
+
+## Current repository release candidates
+
+Prepared release versions in this repository are Python package release candidate: 0.2.0 and Claude plugin/content release candidate: 3.0.1. Individual skill versions remain independent, and JSON schema versions remain at `1`. These candidates are not published releases until maintainers create tags, GitHub release records, and any optional PyPI publication.
+
+Release-readiness commands:
+
+```bash
+python tools/release_audit.py
+python tools/build_release_bundle.py --output-dir dist --source-date-epoch 1783900800
+```
+
+The manual `release-candidate.yml` workflow can be triggered through GitHub Actions `workflow_dispatch` to build unsigned candidate artifacts. Publication remains a maintainer action.
 
 ## Optional MCP policy enforcement
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,7 +220,7 @@ For individual skills:
 - **MINOR** — new sections, new techniques, expanded catalogs.
 - **PATCH** — typo fixes, link updates, severity-tier corrections.
 
-The existing plugin/content release is v3.0. The Python CLI package and individual skill versions are separate domains and may use different numbers.
+The prepared plugin/content release candidate is v3.0.1. The Python CLI package and individual skill versions are separate domains and may use different numbers.
 
 ## Renumbering policy
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -207,7 +207,6 @@ rm -rf ~/.claude/skills/analysis-and-reporting \
 
 Or remove the symlinks if you used method 2 above.
 
-
 ## Local release-candidate artifacts
 
 After maintainers build candidates, install the local Python wheel without claiming PyPI publication:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ The MCP server is optional -- all skills work without it.
 
 ## Python package installation
 
-The Python package version is `0.1.0` and is independent of the Claude plugin/content version `3.0.0`. Install the base CLI from a source checkout with:
+The Python package version is `0.2.0` and is independent of the Claude plugin/content version `3.0.1`. Install the base CLI from a source checkout with:
 
 ```bash
 python -m pip install .
@@ -206,3 +206,15 @@ rm -rf ~/.claude/skills/analysis-and-reporting \
 ```
 
 Or remove the symlinks if you used method 2 above.
+
+
+## Local release-candidate artifacts
+
+After maintainers build candidates, install the local Python wheel without claiming PyPI publication:
+
+```bash
+python -m pip install outrider_recon-0.2.0-py3-none-any.whl
+python -m pip install "outrider_recon-0.2.0-py3-none-any.whl[web]"
+```
+
+Verify the plugin/content bundle separately by inspecting `outrider-recon-bundle-3.0.1.zip` and `RELEASE-MANIFEST.json`. Candidate artifacts are unsigned until a maintainer publishes official release records.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -9,7 +9,7 @@
 | Mode | Status | Notes |
 | --- | --- | --- |
 | Claude skill/content bundle | ready_with_limitations | 11 shipped skills plus `_shared` contract guidance; skills provide methodology and do not bypass deterministic controls. |
-| Base Python CLI | ready | Package version remains `0.1.0`; base runtime depends on PyYAML and provides deterministic run, scope, state, evidence, approval, contract, finding, and discoverability commands. |
+| Base Python CLI | ready | Package version remains `0.2.0`; base runtime depends on PyYAML and provides deterministic run, scope, state, evidence, approval, contract, finding, and discoverability commands. |
 | Optional MCP server | ready_with_limitations | Source-checkout companion with five guarded tools; not included as a base wheel dependency. |
 | Optional local web review plane | ready_with_limitations | Installed with `.[web]`; loopback-only, read-only, no artifact download route, no write route, no Node build. |
 
@@ -19,7 +19,7 @@ Status: **ready**. The package builds as a wheel and source distribution with Py
 
 ## Claude plugin/content status
 
-Status: **ready_with_limitations**. The Claude plugin/content bundle remains version `3.0.0`, independent of the Python package version `0.1.0`. The metadata describes authorized recon methodology and deterministic controls without claiming unrestricted autonomous exploitation.
+Status: **ready_with_limitations**. The Claude plugin/content bundle remains version `3.0.1`, independent of the Python package version `0.2.0`. The metadata describes authorized recon methodology and deterministic controls without claiming unrestricted autonomous exploitation.
 
 ## Skill catalog status
 
@@ -55,7 +55,7 @@ Status: **ready_with_limitations**. Unit tests continue on Python 3.10 and 3.11,
 
 ## Known limitations
 
-- The Python package is still `0.1.0` and should be treated as pre-release until a dedicated version/release PR updates metadata.
+- The Python package is still `0.2.0` and should be treated as pre-release until a dedicated version/release PR updates metadata.
 - The MCP server is a source-checkout companion, not a separately published wheel component.
 - The web review plane has no authentication and is intended for loopback-only local review.
 - Claude skill capabilities are methodology/content capabilities; they are not equivalent to autonomous execution in the Python CLI.
@@ -77,9 +77,20 @@ None identified after this audit. Remaining items are release limitations, not b
 
 **ready_with_limitations:** a version/release PR may proceed after acknowledging the limitations above and after all GitHub Actions jobs pass.
 
-## Version-domain recommendation
+## Historical version-domain recommendation (applied by release preparation)
 
 - **Python package:** next change should be a **minor** version, recommended `0.2.0`, because packaging resources, CLI discoverability, and installed-wheel behavior are materially improved while preserving current semantics.
 - **Claude plugin/content bundle:** next change should be a **patch** version, recommended `3.0.1`, because metadata/documentation truth is corrected without changing skill semantics or skill versions.
 - **Individual skills:** **no version change** is recommended for this audit because skill content semantics are unchanged.
 - **JSON schemas:** **no version change** is recommended because schema semantics remain version `1`.
+
+
+## Applied version decision for release preparation
+
+- Python package `0.2.0` is applied as a minor pre-1.0 release candidate for backward-compatible deterministic control-plane functionality.
+- Claude plugin/content `3.0.1` is applied as a patch release candidate for metadata and documentation truth corrections.
+- Individual skill frontmatter versions are unchanged.
+- Manifest, state-event, evidence, approval, skill-request, skill-result, and finding schemas remain at version `1`.
+- Deterministic candidate artifacts can be built locally or through the manual unsigned release-candidate workflow.
+- No Git tags, GitHub releases, PyPI publication, or Claude plugin publication have occurred in this preparation PR.
+- Status remains **ready_with_limitations** because MCP is source-checkout based, the web plane is loopback-only and unauthenticated, and publication is manual.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -84,7 +84,6 @@ None identified after this audit. Remaining items are release limitations, not b
 - **Individual skills:** **no version change** is recommended for this audit because skill content semantics are unchanged.
 - **JSON schemas:** **no version change** is recommended because schema semantics remain version `1`.
 
-
 ## Applied version decision for release preparation
 
 - Python package `0.2.0` is applied as a minor pre-1.0 release candidate for backward-compatible deterministic control-plane functionality.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,46 @@
+# Outrider release notes
+
+Outrider uses independent version domains:
+
+- Python package release candidates use the Python distribution version.
+- Claude plugin/content release candidates use `.claude-plugin/plugin.json`.
+- Individual skill frontmatter versions are skill-local and do not change for Python 0.2.0 / plugin 3.0.1.
+- Runtime JSON schemas remain schema version 1.
+
+No automatic publication is performed by the release-candidate workflow. Candidate artifacts are unsigned build outputs for maintainer review.
+
+## Recommended tag namespaces
+
+No existing repository tag convention establishes a safe independent version-domain scheme. Use unambiguous future tags after verification:
+
+- Python: `python-v0.2.0`
+- Plugin/content: `plugin-v3.0.1`
+
+Do not create these tags until the manual release checklist is complete.
+
+## Release order
+
+1. Build and verify unsigned candidates from the selected commit.
+2. Create the Python tag if the Python artifacts are accepted.
+3. Create the plugin/content tag if the plugin bundle is accepted.
+4. Create GitHub release records and attach only the matching artifacts.
+5. Optionally publish Python artifacts to PyPI as a separate maintainer action.
+
+## Artifact naming
+
+- `outrider_recon-0.2.0-py3-none-any.whl`
+- `outrider_recon-0.2.0.tar.gz`
+- `outrider-recon-bundle-3.0.1.zip`
+- `SHA256SUMS`
+
+## Verification commands
+
+```bash
+python tools/release_audit.py
+python -m build
+python -m twine check dist/*
+python tools/build_release_bundle.py --output-dir dist --source-date-epoch 1783900800
+sha256sum -c dist/SHA256SUMS
+```
+
+The manual workflow is `release-candidate.yml` and is triggered with `workflow_dispatch` only.

--- a/docs/releases/plugin-3.0.1.md
+++ b/docs/releases/plugin-3.0.1.md
@@ -1,0 +1,47 @@
+# Claude plugin/content 3.0.1 release notes
+
+Claude plugin/content 3.0.1 is a patch release candidate for the existing 3.0 methodology and capability set. It corrects metadata and documentation boundaries without changing individual skill methodology.
+
+## Scope of the patch
+
+- Plugin metadata reports `3.0.1`.
+- The bundle documents 11 shipped skills; `skills/_shared` is shared guidance and is not counted as a twelfth skill.
+- The existing capability count is unchanged.
+- Individual skill frontmatter versions did not change.
+- Python 0.2.0 is a separate version domain.
+
+## Structured-run guidance
+
+Skills continue to use shared structured-run contract guidance. Discovery signals do not expand scope, and skills may produce `finding_candidate` records but must not claim Python-validated findings.
+
+## Deterministic-control relationship
+
+The Claude plugin/content describes methodology. The Python control plane remains authoritative for deterministic scope, state, evidence, approval, MCP guard, contract, and finding checks.
+
+## Optional MCP relationship
+
+MCP enrichment remains optional and guarded. It must honor Python policy decisions and does not expand scope.
+
+## Local web relationship
+
+The optional local web plane is read-only, loopback-oriented review UI for local run data. It does not mutate runs or publish artifacts.
+
+## Installation and update
+
+Use the plugin/content bundle artifact:
+
+- `outrider-recon-bundle-3.0.1.zip`
+
+Extract it into a review directory, inspect `RELEASE-MANIFEST.json`, and follow the repository installation guide. Do not treat the unsigned candidate as an official release until maintainers create the appropriate tags and release records.
+
+## Known limitations
+
+- Candidate artifacts are unsigned.
+- No Git tag, GitHub release, PyPI upload, or plugin publication is performed by this preparation PR.
+- MCP remains a source-checkout companion.
+
+## Checksum verification
+
+```bash
+sha256sum -c SHA256SUMS
+```

--- a/docs/releases/python-0.2.0.md
+++ b/docs/releases/python-0.2.0.md
@@ -1,0 +1,84 @@
+# Python 0.2.0 release notes
+
+Python 0.2.0 is a minor pre-1.0 release candidate for the Outrider Python control plane. It adds substantial backward-compatible functionality without claiming API stability beyond pre-1.0 expectations.
+
+## Major features
+
+- Deterministic scope validation and default-deny scope decisions.
+- Durable run identity, manifests, and workflow state.
+- Evidence registration and integrity verification.
+- Approval records and action-policy decisions.
+- MCP guard integration for source-checkout companion services.
+- Structured skill request/result contracts.
+- Deterministic finding promotion.
+- Optional local loopback-only web review.
+- Packaged skill catalog, schemas, and web resources.
+- Clean-install and release-readiness tooling.
+
+## Security and control boundaries
+
+Python remains authoritative for deterministic scope, state, evidence, approval, action-policy, contract, and finding promotion checks. Denied MCP requests must not perform live network or DNS activity.
+
+## Installation from local artifacts
+
+Base install from a downloaded wheel:
+
+```bash
+python -m pip install outrider_recon-0.2.0-py3-none-any.whl
+```
+
+Optional web review dependencies from a downloaded wheel:
+
+```bash
+python -m pip install "outrider_recon-0.2.0-py3-none-any.whl[web]"
+```
+
+This release note does not claim that `outrider-recon==0.2.0` has been published to PyPI.
+
+## MCP companion limitation
+
+The MCP server remains an optional source-checkout companion. It is not required for the base wheel and is not advertised as an installed console script in this candidate.
+
+## Supported Python versions
+
+The project CI covers Python 3.10, 3.11, and 3.12.
+
+## Upgrade notes from 0.1.0
+
+Upgrade local wheel installs by replacing the installed 0.1.0 wheel with the 0.2.0 candidate. Existing deterministic run-folder schemas remain version 1.
+
+## Compatibility notes
+
+- Plugin/content version 3.0.1 is a separate domain.
+- Individual skill versions remain unchanged.
+- JSON schema versions remain at 1.
+
+## Known limitations
+
+- Release publication, Git tags, and GitHub release records are manual maintainer actions.
+- Web review is loopback-only and unauthenticated; bind it only to trusted local interfaces.
+- MCP enrichment remains optional and source-checkout based.
+
+## Verification commands
+
+```bash
+outrider --version
+python -m outrider --version
+python tools/release_audit.py
+python -m twine check dist/*
+sha256sum -c dist/SHA256SUMS
+```
+
+## Artifact names
+
+- `outrider_recon-0.2.0-py3-none-any.whl`
+- `outrider_recon-0.2.0.tar.gz`
+- `SHA256SUMS`
+
+## Checksum verification
+
+Place the artifacts and `SHA256SUMS` in the same directory, then run:
+
+```bash
+sha256sum -c SHA256SUMS
+```

--- a/docs/releases/release-checklist.md
+++ b/docs/releases/release-checklist.md
@@ -1,0 +1,60 @@
+# Manual release checklist
+
+This checklist is for a future maintainer-operated release. This PR does not perform tagging, publication, GitHub release creation, PyPI upload, or plugin publication.
+
+## 1. Pre-tag verification
+
+- Confirm the selected commit is on `main` and CI has passed.
+- Run `python tools/release_audit.py` and review limitations.
+- Confirm Python `0.2.0`, plugin/content `3.0.1`, 11 skills, and schema version 1.
+
+## 2. Build candidate artifacts
+
+- Run the manual release-candidate workflow or build locally.
+- Build wheel, sdist, plugin/content bundle, and `SHA256SUMS`.
+
+## 3. Inspect artifacts
+
+- Inspect wheel and sdist metadata.
+- Inspect `outrider-recon-bundle-3.0.1.zip` contents and `RELEASE-MANIFEST.json`.
+- Confirm no tests, CI, caches, run data, credentials, or local artifacts are present.
+
+## 4. Verify checksums
+
+- Run `sha256sum -c SHA256SUMS` in the artifact directory.
+
+## 5. Create Python tag
+
+- After acceptance, create `python-v0.2.0` from the verified commit.
+
+## 6. Create plugin/content tag
+
+- After acceptance, create `plugin-v3.0.1` from the verified commit.
+
+## 7. Create GitHub release or releases
+
+- Create release records after tags exist.
+- Mark candidates appropriately if not final.
+
+## 8. Attach correct artifacts
+
+- Attach Python artifacts to the Python release record.
+- Attach plugin/content bundle and checksums to the plugin/content release record.
+
+## 9. Optional PyPI publication
+
+- Publish only after maintainer approval using secure external publishing configuration.
+- Do not store credentials or tokens in repository files.
+
+## 10. Post-release installation verification
+
+- Install the published wheel in clean base and web environments.
+- Verify `outrider --version` reports `0.2.0`.
+
+## 11. Documentation verification
+
+- Confirm documentation no longer describes accepted artifacts as unpublished candidates once publication actually occurs.
+
+## 12. Rollback response
+
+- If a release error is found, document affected artifacts, remove or supersede broken release records as appropriate, and publish corrected artifacts from a new verified commit.

--- a/outrider/__init__.py
+++ b/outrider/__init__.py
@@ -1,3 +1,11 @@
 """Outrider Recon CLI harness."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+import tomllib
+
+try:
+    __version__ = version("outrider-recon")
+except PackageNotFoundError:  # pragma: no cover - source tree fallback
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    __version__ = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]

--- a/outrider/__init__.py
+++ b/outrider/__init__.py
@@ -2,10 +2,9 @@
 
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-import tomllib
 
 try:
     __version__ = version("outrider-recon")
 except PackageNotFoundError:  # pragma: no cover - source tree fallback
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    __version__ = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+    __version__ = next(line.split("=", 1)[1].strip().strip("\"'") for line in pyproject.read_text(encoding="utf-8").splitlines() if line.strip().startswith("version ="))

--- a/outrider/cli.py
+++ b/outrider/cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 from importlib.metadata import PackageNotFoundError, version
-import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
@@ -56,7 +55,7 @@ def package_version() -> str:
         return version("outrider-recon")
     except PackageNotFoundError:  # pragma: no cover - source tree fallback
         pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-        return tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+        return next(line.split("=", 1)[1].strip().strip("\"'") for line in pyproject.read_text(encoding="utf-8").splitlines() if line.strip().startswith("version ="))
 
 def _valid_web_port(value: str) -> int:
     try:

--- a/outrider/cli.py
+++ b/outrider/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from importlib.metadata import PackageNotFoundError, version
+import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
@@ -54,7 +55,8 @@ def package_version() -> str:
     try:
         return version("outrider-recon")
     except PackageNotFoundError:  # pragma: no cover - source tree fallback
-        return "0.1.0"
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        return tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
 
 def _valid_web_port(value: str) -> int:
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "outrider-recon"
-version = "0.1.0"
+version = "0.2.0"
 description = "Claude-native external recon and ASM harness for prioritized, evidence-backed handoff."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import contextlib, hashlib, io, json, os, subprocess, sys, tempfile, unittest, zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'tools'))
+import build_release_bundle
+
+class ReleaseBundleTests(unittest.TestCase):
+    def build(self, td: str, *extra: str):
+        return subprocess.run([sys.executable, str(ROOT/'tools/build_release_bundle.py'), '--output-dir', td, '--source-date-epoch', '1783900800', *extra], cwd=ROOT, text=True, capture_output=True)
+
+    def test_bundle_contents_manifest_and_determinism(self):
+        with tempfile.TemporaryDirectory() as td1, tempfile.TemporaryDirectory() as td2:
+            cp=self.build(td1); self.assertEqual(cp.returncode,0,cp.stderr+cp.stdout)
+            archive=Path(td1)/'outrider-recon-bundle-3.0.1.zip'
+            self.assertTrue(archive.exists())
+            with zipfile.ZipFile(archive) as z:
+                names=z.namelist()
+                self.assertTrue(all(n.startswith('outrider-recon-bundle-3.0.1/') for n in names))
+                self.assertFalse(any('/tests/' in n or '/.github/' in n or '__pycache__' in n or '/dist/' in n or n.startswith('/') or '..' in Path(n).parts for n in names))
+                for required in ['README.md','.claude-plugin/plugin.json','pyproject.toml','outrider/skill_catalog.json','contracts/skill-request-v1.schema.json','skills/_shared/run-contract.md','tools/build_release_bundle.py']:
+                    self.assertIn('outrider-recon-bundle-3.0.1/'+required, names)
+                skills={Path(n).parts[2] for n in names if n.endswith('/SKILL.md') and Path(n).parts[1]=='skills' and Path(n).parts[2] != '_shared'}
+                self.assertEqual(len(skills),11)
+                manifest=json.loads(z.read('outrider-recon-bundle-3.0.1/RELEASE-MANIFEST.json'))
+                self.assertEqual(manifest['python_version'],'0.2.0')
+                self.assertEqual(manifest['plugin_version'],'3.0.1')
+                self.assertEqual(manifest['skill_count'],11)
+                self.assertEqual(set(manifest['schema_versions'].values()), {1})
+                paths=[f['path'] for f in manifest['files']]
+                self.assertEqual(paths, sorted(paths))
+                self.assertNotIn('RELEASE-MANIFEST.json', paths)
+                for entry in manifest['files'][:25]:
+                    data=z.read('outrider-recon-bundle-3.0.1/'+entry['path'])
+                    self.assertEqual(hashlib.sha256(data).hexdigest(), entry['sha256'])
+                    self.assertEqual(len(data), entry['size_bytes'])
+            cp2=self.build(td2); self.assertEqual(cp2.returncode,0,cp2.stderr+cp2.stdout)
+            h1=hashlib.sha256(archive.read_bytes()).hexdigest()
+            h2=hashlib.sha256((Path(td2)/archive.name).read_bytes()).hexdigest()
+            self.assertEqual(h1,h2)
+
+    def test_output_refusal_force_and_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(self.build(td).returncode,0)
+            self.assertEqual(self.build(td).returncode,2)
+            cp=self.build(td,'--force','--json')
+            self.assertEqual(cp.returncode,0,cp.stderr+cp.stdout)
+            data=json.loads(cp.stdout)
+            self.assertEqual(data['bundle_filename'],'outrider-recon-bundle-3.0.1.zip')
+            self.assertRegex(data['bundle_sha256'], r'^[0-9a-f]{64}$')
+
+    def test_rejects_unexpected_symlink(self):
+        original=build_release_bundle.ALLOWLIST_FILES
+        try:
+            with tempfile.TemporaryDirectory(dir=ROOT) as td:
+                rel=Path(td).relative_to(ROOT)/'bad-link'
+                os.symlink('/etc/passwd', ROOT/rel)
+                build_release_bundle.ALLOWLIST_FILES = []
+                build_release_bundle.ALLOWLIST_DIRS = [str(rel.parent)]
+                with self.assertRaises(build_release_bundle.BundleError):
+                    build_release_bundle.collect_files()
+        finally:
+            try: (ROOT/rel).unlink()
+            except Exception: pass
+            build_release_bundle.ALLOWLIST_FILES = original
+            build_release_bundle.ALLOWLIST_DIRS = ['outrider', 'contracts', 'skills', 'mcp-server', 'docs', 'examples']
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -60,8 +60,8 @@ class ReleaseReadinessTests(unittest.TestCase):
 
     def test_version_inventory_and_independent_domains(self):
         versions=release_audit.Audit(ROOT).versions()
-        self.assertEqual(versions['python_package'],'0.1.0')
-        self.assertEqual(versions['claude_plugin'],'3.0.0')
+        self.assertEqual(versions['python_package'],'0.2.0')
+        self.assertEqual(versions['claude_plugin'],'3.0.1')
         self.assertNotEqual(versions['python_package'], versions['claude_plugin'])
         self.assertEqual(set(versions['schemas'].values()), {1})
 
@@ -80,7 +80,7 @@ class ReleaseReadinessTests(unittest.TestCase):
             self.assertEqual(json.loads((ROOT/'contracts'/name).read_text()), schema_json(name))
         for name in ['index.html','app.css','app.js']:
             self.assertTrue(web_static_path(name).exists())
-        self.assertEqual(json.loads((ROOT/'.claude-plugin/plugin.json').read_text())['version'], '3.0.0')
+        self.assertEqual(json.loads((ROOT/'.claude-plugin/plugin.json').read_text())['version'], '3.0.1')
         for i in range(1,8):
             self.assertTrue(list((ROOT/'docs/adr').glob(f'{i:04d}-*.md')))
 
@@ -127,7 +127,46 @@ class ReleaseReadinessTests(unittest.TestCase):
             cp=subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
             self.assertEqual(cp.returncode, 0, cp.stderr+cp.stdout)
         from outrider.cli import package_version
-        self.assertRegex(package_version(), r'^\d+\.\d+\.\d+')
+        self.assertEqual(package_version(), '0.2.0')
+
+
+    def test_release_notes_changelog_and_workflow(self):
+        changelog=(ROOT/'CHANGELOG.md').read_text()
+        self.assertIn('## [Unreleased]', changelog)
+        self.assertRegex(changelog, r'## \[Python 0\.2\.0\] -- \d{4}-\d{2}-\d{2}')
+        self.assertRegex(changelog, r'## \[Claude plugin/content 3\.0\.1\] -- \d{4}-\d{2}-\d{2}')
+        unreleased=changelog.split('## [Unreleased]',1)[1].split('---',1)[0]
+        self.assertNotIn('deterministic scope checks', unreleased)
+        for rel in ['README.md','python-0.2.0.md','plugin-3.0.1.md','release-checklist.md']:
+            self.assertTrue((ROOT/'docs/releases'/rel).exists())
+        py_notes=(ROOT/'docs/releases/python-0.2.0.md').read_text().lower()
+        self.assertNotIn('pip install outrider-recon==0.2.0', py_notes)
+        plugin_notes=(ROOT/'docs/releases/plugin-3.0.1.md').read_text()
+        self.assertIn('Python 0.2.0 is a separate version domain', plugin_notes)
+        docs='\n'.join(p.read_text(errors='ignore') for p in [ROOT/'README.md', ROOT/'docs/installation.md', ROOT/'docs/architecture.md'])
+        self.assertNotIn('Python package version `3.0.1`', docs)
+        wf=(ROOT/'.github/workflows/release-candidate.yml').read_text()
+        import yaml
+        parsed=yaml.safe_load(wf)
+        self.assertIsInstance(parsed, dict)
+        self.assertIn('workflow_dispatch:', wf)
+        self.assertNotIn('pull_request:', wf)
+        self.assertNotIn('push:', wf)
+        self.assertIn('contents: read', wf)
+        for bad in ['contents: write','packages: write','id-token: write','actions: write','twine upload','gh release create','git tag','git push','secrets.']:
+            self.assertNotIn(bad, wf)
+        for needed in ['tools/release_audit.py','unittest discover','compileall','python -m build','twine check','tools/build_release_bundle.py','SHA256SUMS','Clean base install','Clean web install','actions/upload-artifact@v4']:
+            self.assertIn(needed, wf)
+
+    def test_skill_and_schema_version_preservation(self):
+        expected={
+            'analysis-and-reporting': '1.0.0', 'cloud-and-infra': '1.1.0', 'identity-fabric': '1.0.0',
+            'offensive-osint': '2.1.1', 'osint-methodology': '2.2', 'people-breach-intel': '1.0.0',
+            'post-discovery': '1.0.0', 'recon-asset-discovery': '1.0.0', 'report-template': '1.0.0',
+            'secrets-and-dorks': '1.0.0', 'web-surface': '1.0.0'}
+        self.assertEqual(release_audit.Audit(ROOT).versions()['skills'], expected)
+        self.assertNotIn('_shared', expected)
+        self.assertEqual(set(release_audit.Audit(ROOT).versions()['schemas'].values()), {1})
 
     def test_audit_is_read_only_and_no_network(self):
         before={p: p.stat().st_mtime_ns for p in ROOT.rglob('*') if p.is_file() and '.git' not in p.parts}

--- a/tools/build_release_bundle.py
+++ b/tools/build_release_bundle.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import stat
+import sys
+import zipfile
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_VERSION = "0.2.0"
+PLUGIN_VERSION = "3.0.1"
+BUNDLE = "outrider-recon"
+ARCHIVE_NAME = f"{BUNDLE}-bundle-{PLUGIN_VERSION}.zip"
+ROOT_DIR = f"{BUNDLE}-bundle-{PLUGIN_VERSION}"
+ALLOWLIST_FILES = [
+    ".claude-plugin/plugin.json", ".mcp.json", ".gitignore", "pyproject.toml", "README.md", "CHANGELOG.md",
+    "LICENSE", "SECURITY.md", "CONTRIBUTING.md", "CLAUDE.md.example", "install.sh", "uninstall.sh",
+    "tools/release_audit.py", "tools/build_release_bundle.py",
+]
+ALLOWLIST_DIRS = ["outrider", "contracts", "skills", "mcp-server", "docs", "examples"]
+EXCLUDED_NAMES = {".git", ".github", "tests", "dist", "build", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "artifacts", "runs"}
+EXCLUDED_SUFFIXES = (".pyc", ".pyo", ".log")
+EXCLUDED_EXACT = {"evidence.jsonl", "approvals.jsonl", "findings.jsonl", "manifest.json", ".env"}
+SCHEMA_VERSIONS = {"manifest": 1, "state_event": 1, "evidence": 1, "approval": 1, "skill_request": 1, "skill_result": 1, "finding": 1}
+
+class BundleError(Exception):
+    pass
+
+def read_py_version() -> str:
+    import tomllib
+    return tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+
+def skill_names() -> list[str]:
+    return sorted(p.parent.name for p in (ROOT / "skills").glob("*/SKILL.md") if p.parent.name != "_shared")
+
+def validate_versions() -> list[str]:
+    py = read_py_version()
+    plugin = json.loads((ROOT / ".claude-plugin/plugin.json").read_text())["version"]
+    if py != PYTHON_VERSION or plugin != PLUGIN_VERSION or py == plugin:
+        raise BundleError(f"version mismatch: python={py!r} plugin={plugin!r}")
+    skills = skill_names()
+    if len(skills) != 11:
+        raise BundleError(f"expected 11 skills, found {len(skills)}")
+    for schema in ["skill-request-v1.schema.json", "skill-result-v1.schema.json", "finding-v1.schema.json"]:
+        data = json.loads((ROOT / "contracts" / schema).read_text())
+        if data.get("properties", {}).get("schema_version", {}).get("const") != 1:
+            raise BundleError(f"schema version changed: {schema}")
+    return skills
+
+def is_excluded(rel: Path) -> bool:
+    parts = rel.parts
+    if len(parts) >= 2 and parts[0] == "examples" and parts[1] == "run-folder":
+        return True
+    if any(part in EXCLUDED_NAMES for part in parts):
+        return True
+    if rel.name.endswith(".egg-info") or rel.name in EXCLUDED_EXACT or rel.suffix in EXCLUDED_SUFFIXES:
+        return True
+    if rel.name.startswith(".env") or rel.name in {".DS_Store"}:
+        return True
+    return False
+
+def assert_safe(rel: Path, path: Path) -> None:
+    if path.is_symlink():
+        raise BundleError(f"unexpected symlink: {rel.as_posix()}")
+    posix = rel.as_posix()
+    pure = PurePosixPath(posix)
+    if posix.startswith("/") or ".." in pure.parts:
+        raise BundleError(f"unsafe path: {posix}")
+    try:
+        path.resolve().relative_to(ROOT.resolve())
+    except ValueError as exc:
+        raise BundleError(f"path escapes repository: {posix}") from exc
+
+def collect_files() -> list[Path]:
+    files: set[Path] = set()
+    for name in ALLOWLIST_FILES:
+        p = ROOT / name
+        if not p.is_file():
+            raise BundleError(f"missing release input: {name}")
+        files.add(Path(name))
+    for dirname in ALLOWLIST_DIRS:
+        base = ROOT / dirname
+        if not base.is_dir():
+            raise BundleError(f"missing release input: {dirname}")
+        for p in base.rglob("*"):
+            rel = p.relative_to(ROOT)
+            if is_excluded(rel):
+                continue
+            assert_safe(rel, p)
+            if p.is_file():
+                files.add(rel)
+            elif p.is_symlink():
+                raise BundleError(f"unexpected symlink: {rel.as_posix()}")
+    return sorted(files, key=lambda x: x.as_posix())
+
+def digest(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+def zip_info(name: str, epoch: int, mode: int = 0o644) -> zipfile.ZipInfo:
+    z = zipfile.ZipInfo(name, dt.datetime.fromtimestamp(epoch, dt.timezone.utc).timetuple()[:6])
+    z.compress_type = zipfile.ZIP_DEFLATED
+    z.external_attr = (stat.S_IFREG | mode) << 16
+    return z
+
+def build(output_dir: Path, epoch: int, force: bool) -> dict[str, object]:
+    skills = validate_versions()
+    files = collect_files()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive = output_dir / ARCHIVE_NAME
+    if archive.exists():
+        if not force:
+            raise BundleError(f"output already exists: {archive}")
+        archive.unlink()
+    manifest_files = []
+    for rel in files:
+        p = ROOT / rel
+        manifest_files.append({"path": rel.as_posix(), "sha256": digest(p), "size_bytes": p.stat().st_size})
+    manifest = {
+        "schema_version": 1,
+        "bundle": BUNDLE,
+        "plugin_version": PLUGIN_VERSION,
+        "python_version": PYTHON_VERSION,
+        "generated_at": dt.datetime.fromtimestamp(epoch, dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "skill_count": len(skills),
+        "skills": skills,
+        "schema_versions": SCHEMA_VERSIONS,
+        "files": manifest_files,
+    }
+    with zipfile.ZipFile(archive, "w") as zf:
+        for rel in files:
+            mode = 0o755 if rel.name in {"install.sh", "uninstall.sh", "build_release_bundle.py", "release_audit.py"} else 0o644
+            zf.writestr(zip_info(f"{ROOT_DIR}/{rel.as_posix()}", epoch, mode), (ROOT / rel).read_bytes())
+        zf.writestr(zip_info(f"{ROOT_DIR}/RELEASE-MANIFEST.json", epoch), json.dumps(manifest, indent=2, sort_keys=True).encode() + b"\n")
+    return {"python_version": PYTHON_VERSION, "plugin_version": PLUGIN_VERSION, "skill_count": len(skills), "file_count": len(files), "bundle_filename": archive.name, "bundle_sha256": digest(archive), "bundle_size": archive.stat().st_size, "bundle_path": str(archive)}
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output-dir", default="dist")
+    ap.add_argument("--source-date-epoch", type=int, default=None)
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--force", action="store_true")
+    args = ap.parse_args(argv)
+    epoch = args.source_date_epoch if args.source_date_epoch is not None else int(os.environ.get("SOURCE_DATE_EPOCH", "0"))
+    try:
+        result = build(Path(args.output_dir), epoch, args.force)
+    except Exception as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, sort_keys=True))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print(f"Python version: {result['python_version']}")
+        print(f"Plugin/content version: {result['plugin_version']}")
+        print(f"Skill count: {result['skill_count']}")
+        print(f"File count: {result['file_count']}")
+        print(f"Bundle filename: {result['bundle_filename']}")
+        print(f"Bundle SHA-256: {result['bundle_sha256']}")
+        print(f"Bundle size: {result['bundle_size']}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/build_release_bundle.py
+++ b/tools/build_release_bundle.py
@@ -32,8 +32,17 @@ class BundleError(Exception):
     pass
 
 def read_py_version() -> str:
-    import tomllib
-    return tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+    in_project = False
+    for raw in (ROOT / "pyproject.toml").read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line == "[project]":
+            in_project = True
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_project = False
+        if in_project and line.startswith("version") and "=" in line:
+            return line.split("=", 1)[1].strip().strip("\"'")
+    raise BundleError("pyproject.toml missing [project] version")
 
 def skill_names() -> list[str]:
     return sorted(p.parent.name for p in (ROOT / "skills").glob("*/SKILL.md") if p.parent.name != "_shared")

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-REQUIRED_FILES = ['pyproject.toml','README.md','CHANGELOG.md','SECURITY.md','CONTRIBUTING.md','LICENSE','install.sh','uninstall.sh','.gitignore','.mcp.json','.claude-plugin/plugin.json','.github/workflows/lint.yml']
+REQUIRED_FILES = ['pyproject.toml','README.md','CHANGELOG.md','SECURITY.md','CONTRIBUTING.md','LICENSE','install.sh','uninstall.sh','.gitignore','.mcp.json','.claude-plugin/plugin.json','.github/workflows/lint.yml','.github/workflows/release-candidate.yml','tools/build_release_bundle.py','docs/releases/README.md','docs/releases/python-0.2.0.md','docs/releases/plugin-3.0.1.md','docs/releases/release-checklist.md']
 SCHEMAS = ['skill-request-v1.schema.json','skill-result-v1.schema.json','finding-v1.schema.json']
 WEB_STATIC = ['index.html','app.css','app.js']
 ADRS = [f'docs/adr/{i:04d}-{name}.md' for i,name in [(1,'run-manifest-and-state-log'),(2,'evidence-registry-and-integrity'),(3,'approval-registry-and-action-policy'),(4,'mcp-tool-boundary-enforcement'),(5,'skill-python-interchange-contracts'),(6,'deterministic-finding-promotion'),(7,'local-web-review-plane')]]
@@ -85,9 +85,33 @@ class Audit:
         schemas={p.name: json.loads(p.read_text()).get('properties',{}).get('schema_version',{}).get('const') for p in (self.root/'contracts').glob('*.schema.json')}
         return {'python_package':py['project']['version'],'claude_plugin':plugin['version'],'skills':skills,'schemas':schemas,'manifest_schema':1,'state_event_schema':1,'evidence_schema':1,'approval_schema':1,'finding_schema':schemas.get('finding-v1.schema.json')}
     def run(self):
-        self.check_required_files(); self.check_parse(); self.check_skills(); self.check_schemas(); self.check_package_data(); self.check_static(); self.check_adrs(); self.check_artifacts(); self.check_security_patterns(); self.check_docs_versions(); self.check_mcp(); return self
+        self.check_required_files(); self.check_parse(); self.check_versions(); self.check_skills(); self.check_schemas(); self.check_package_data(); self.check_static(); self.check_adrs(); self.check_artifacts(); self.check_security_patterns(); self.check_docs_versions(); self.check_changelog(); self.check_release_workflow(); self.check_mcp(); return self
+
+    def check_versions(self):
+        versions = self.versions()
+        expected_skills = {
+            'analysis-and-reporting': '1.0.0', 'cloud-and-infra': '1.1.0', 'identity-fabric': '1.0.0',
+            'offensive-osint': '2.1.1', 'osint-methodology': '2.2', 'people-breach-intel': '1.0.0',
+            'post-discovery': '1.0.0', 'recon-asset-discovery': '1.0.0', 'report-template': '1.0.0',
+            'secrets-and-dorks': '1.0.0', 'web-surface': '1.0.0'}
+        if versions['python_package'] == '0.2.0' and versions['claude_plugin'] == '3.0.1' and versions['python_package'] != versions['claude_plugin']:
+            self.ok('independent release versions','Python 0.2.0 and plugin/content 3.0.1 are distinct')
+        else:
+            self.fail('independent release versions',f"unexpected versions: {versions['python_package']} / {versions['claude_plugin']}")
+        if versions['skills'] == expected_skills:
+            self.ok('skill version preservation','all 11 skill frontmatter versions match the release-readiness baseline')
+        else:
+            self.fail('skill version preservation','skill versions changed')
+        if set(versions['schemas'].values()) == {1} and all(versions[k] == 1 for k in ['manifest_schema','state_event_schema','evidence_schema','approval_schema','finding_schema']):
+            self.ok('schema version preservation','all runtime schemas remain version 1')
+        else:
+            self.fail('schema version preservation','schema versions changed')
+
+    def is_bundle_root(self):
+        return (self.root/"RELEASE-MANIFEST.json").exists()
     def check_required_files(self):
-        missing=[f for f in REQUIRED_FILES if not (self.root/f).exists()]
+        required = [f for f in REQUIRED_FILES if not (self.is_bundle_root() and f.startswith((".github/", "tests/")))]
+        missing=[f for f in required if not (self.root/f).exists()]
         self.ok('required repository files','all required files are present') if not missing else self.fail('required repository files','missing '+', '.join(missing))
     def check_parse(self):
         try: load_pyproject(self.root/'pyproject.toml'); self.ok('pyproject parseability','pyproject.toml parses')
@@ -162,8 +186,54 @@ class Audit:
         else: self.ok('obvious secret-like patterns','no unexpected secret-like patterns found; documented fixtures/examples are allowlisted')
     def check_docs_versions(self):
         text='\n'.join((self.root/p).read_text(errors='ignore') for p in ['README.md','docs/installation.md','docs/architecture.md','SECURITY.md','.claude-plugin/plugin.json','CHANGELOG.md'] if (self.root/p).exists())
-        if 'Python package 0.1.0' in text and 'Claude plugin/content 3.0.0' in text: self.ok('documentation version-domain references','Python and Claude plugin versions are documented independently')
-        else: self.warn('documentation version-domain references','version-domain independence should be stated in public docs')
+        if 'Python package release candidate: 0.2.0' in text or 'Python package release candidate `0.2.0`' in text or 'Python package `0.2.0`' in text:
+            if 'Claude plugin/content release candidate: 3.0.1' in text or 'Claude plugin/content release candidate `3.0.1`' in text or 'Claude plugin/content `3.0.1`' in text:
+                self.ok('documentation version-domain references','Python and Claude plugin versions are documented independently')
+                return
+        self.warn('documentation version-domain references','version-domain independence should be stated in public docs')
+
+    def check_changelog(self):
+        text=(self.root/'CHANGELOG.md').read_text(errors='ignore')
+        unreleased=text.split('## [Unreleased]',1)[1].split('---',1)[0] if '## [Unreleased]' in text else ''
+        if re.search(r'## \[Python 0\.2\.0\] -- \d{4}-\d{2}-\d{2}', text) and re.search(r'## \[Claude plugin/content 3\.0\.1\] -- \d{4}-\d{2}-\d{2}', text):
+            self.ok('release-domain changelog sections','Python and plugin/content sections are dated')
+        else:
+            self.fail('release-domain changelog sections','missing dated release-domain sections')
+        released_terms=['deterministic scope checks','Claude plugin/content bundle as `3.0.1`','Python package as `0.2.0`']
+        if not any(term in unreleased for term in released_terms):
+            self.ok('unreleased changelog cleanup','released entries are not duplicated under Unreleased')
+        else:
+            self.fail('unreleased changelog cleanup','released entries remain under Unreleased')
+
+    def check_release_workflow(self):
+        if self.is_bundle_root():
+            self.ok('release-candidate workflow exclusion','release bundle intentionally excludes .github workflow files')
+            return
+        path=self.root/'.github/workflows/release-candidate.yml'
+        text=path.read_text(errors='ignore') if path.exists() else ''
+        if 'workflow_dispatch:' in text and not re.search(r'\n\s+(push|pull_request):', text):
+            self.ok('release-candidate workflow trigger','workflow_dispatch is the only trigger')
+        else:
+            self.fail('release-candidate workflow trigger','release workflow must be manual only')
+        if re.search(r'permissions:\s*\n\s*contents:\s*read', text) and not re.search(r'contents:\s*write|packages:\s*write|id-token:\s*write|actions:\s*write', text):
+            self.ok('release-candidate workflow permissions','workflow has read-only contents permission')
+        else:
+            self.fail('release-candidate workflow permissions','workflow must not request write permissions')
+        forbidden=['pypi', 'twine upload', 'gh release create', 'git tag', 'git push', 'secrets.']
+        hits=[x for x in forbidden if x in text.lower()]
+        allowed=[x for x in hits if x == 'pypi' and 'no pypi' in text.lower()]
+        hits=[x for x in hits if x not in allowed]
+        if not hits:
+            self.ok('release-candidate workflow non-publication','no publication, tag, push, or secret usage detected')
+        else:
+            self.fail('release-candidate workflow non-publication','forbidden terms: '+', '.join(hits))
+        required=['tools/release_audit.py','unittest discover','compileall','python -m build','twine check','tools/build_release_bundle.py','SHA256SUMS','actions/upload-artifact@v4']
+        missing=[x for x in required if x not in text]
+        if not missing:
+            self.ok('release-candidate workflow steps','candidate workflow builds, tests, checks, bundles, checksums, and uploads unsigned candidates')
+        else:
+            self.fail('release-candidate workflow steps','missing '+', '.join(missing))
+
     def check_mcp(self):
         s=(self.root/'mcp-server/server.py').read_text()
         tools=s.count('@mcp.tool')


### PR DESCRIPTION
### Motivation

- Apply the merged release-readiness audit recommendations to prepare reproducible, unsigned release-candidate artifacts for both the Python package and Claude plugin/content domains. 
- Preserve all individual skill frontmatter versions and runtime JSON schema versions while documenting independent version domains and operator release steps. 
- Add deterministic plugin/content bundling and a manual candidate workflow so maintainers can build, inspect, and verify artifacts without publishing.

### Description

- Updated the Python package version in `pyproject.toml` to `0.2.0` and updated the Claude plugin content version in `.claude-plugin/plugin.json` to `3.0.1`. 
- Added a deterministic bundle tool `tools/build_release_bundle.py` that produces `outrider-recon-bundle-3.0.1.zip` with a `RELEASE-MANIFEST.json` and stable SHA-256s, and added `tests/test_release_bundle.py` to validate bundle behavior and determinism. 
- Added manual release documentation under `docs/releases/` (`README.md`, `python-0.2.0.md`, `plugin-3.0.1.md`, `release-checklist.md`), added a manual `release-candidate` GitHub Actions workflow at `.github/workflows/release-candidate.yml`, and updated `docs/installation.md`, `docs/architecture.md`, `docs/release-readiness.md`, and `README.md` to reference prepared candidates. 
- Updated `tools/release_audit.py` to expect `python 0.2.0` and `plugin 3.0.1`, to verify unchanged skill and schema versions, to check for release note files and the manual workflow, and to validate workflow triggers/permissions; updated CLI/source-tree fallback so package-version discovery uses `pyproject.toml` when the distribution is not installed. 
- Tests: added `tests/test_release_bundle.py` and updated `tests/test_release_readiness.py` to assert the version-domain changes, unchanged skill/schema inventories, changelog/release-note presence, workflow safety properties, and bundle contents.

### Testing

- `python tools/release_audit.py` and `python tools/release_audit.py --json` both passed and reported overall status `ready` (or `ready_with_limitations` as expected earlier); check verifies Python `0.2.0`, plugin `3.0.1`, 11 skills, and schema versions remain `1`. 
- Unit tests: `python -m unittest discover -s tests -p "test_*.py"` executed 94 tests with 4 skipped and all assertions passed. 
- Bytecode compile: `python -m compileall outrider tests mcp-server tools` passed. 
- Deterministic bundle: `tools/build_release_bundle.py --output-dir dist --source-date-epoch 1783900800` succeeded and produced `outrider-recon-bundle-3.0.1.zip` and `dist/SHA256SUMS`; repeated builds with the same epoch produced identical archives and the bundle manifest validated (manifest lists Python `0.2.0`, plugin `3.0.1`, skill_count `11`). 
- Release-candidate packaging checks: `sha256sum -c dist/SHA256SUMS` passed for the locally generated bundle candidate; `python tools/release_audit.py` run against the extracted bundle passed (bundle-aware exclusions handled). 
- Local `wheel`/`sdist` build and `twine check` could not be run in this environment because installation of build tooling (`build`, `twine`, `setuptools` back-end dependencies) was blocked by package-index/network restrictions; the release-candidate workflow includes those steps and is expected to run in CI where network access for installing build tooling is available. 

Files changed (key items): `pyproject.toml`, `.claude-plugin/plugin.json`, `CHANGELOG.md`, `README.md`, `docs/installation.md`, `docs/architecture.md`, `docs/release-readiness.md`, `docs/releases/*`, `tools/build_release_bundle.py`, `tools/release_audit.py`, `.github/workflows/release-candidate.yml`, `tests/test_release_bundle.py`, `tests/test_release_readiness.py`, `outrider/__init__.py`, `outrider/cli.py`.

(Testing environment: `/root/.pyenv/shims/python` — Python 3.12.13.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a546031b488833099eeede6550f1625)