### PR TITLE
fix: repair release-candidate web smoke test

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -66,10 +66,30 @@ jobs:
           python -m venv /tmp/outrider-web
           /tmp/outrider-web/bin/python -m pip install "dist/outrider_recon-0.2.0-py3-none-any.whl[web]"
           /tmp/outrider-web/bin/python - <<'PY'
+          from pathlib import Path
+          from tempfile import TemporaryDirectory
+
           from fastapi.testclient import TestClient
           from outrider.web_app import create_app
-          c=TestClient(create_app())
-          assert c.get('/').status_code in (200, 404)
+
+          with TemporaryDirectory() as temporary_directory:
+              runs_root = Path(temporary_directory) / "runs"
+              runs_root.mkdir()
+
+              client = TestClient(create_app(runs_root))
+
+              health = client.get("/api/health")
+              assert health.status_code == 200
+              assert health.json() == {
+                  "ok": True,
+                  "service": "outrider-web",
+                  "mode": "read-only",
+                  "network_scope": "loopback-only",
+              }
+
+              assert client.get("/").status_code == 200
+              assert client.get("/static/app.css").status_code == 200
+              assert client.get("/static/app.js").status_code == 200
           PY
       - name: Verify bundle manifest
         run: |

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -153,6 +153,22 @@ class ReleaseReadinessTests(unittest.TestCase):
         self.assertNotIn('pull_request:', wf)
         self.assertNotIn('push:', wf)
         self.assertIn('contents: read', wf)
+        clean_web_step = next(
+            step for step in parsed['jobs']['build-candidates']['steps']
+            if step.get('name') == 'Clean web install smoke'
+        )
+        clean_web_script = clean_web_step['run']
+        self.assertIn('TemporaryDirectory', clean_web_script)
+        self.assertRegex(clean_web_script, r'runs_root\s*=\s*Path\([^\n]+\)\s*/\s*[\"\']runs[\"\']')
+        self.assertIn('runs_root.mkdir()', clean_web_script)
+        self.assertRegex(clean_web_script, r'create_app\(\s*runs_root\s*\)')
+        self.assertNotRegex(clean_web_script, r'create_app\(\s*\)')
+        for path in ['/api/health', '/', '/static/app.css', '/static/app.js']:
+            self.assertIn(path, clean_web_script)
+        self.assertIn('health.status_code == 200', clean_web_script)
+        self.assertIn('client.get("/").status_code == 200', clean_web_script)
+        self.assertNotIn('uvicorn', clean_web_script.lower())
+        self.assertNotIn('0.0.0.0', clean_web_script)
         for bad in ['contents: write','packages: write','id-token: write','actions: write','twine upload','gh release create','git tag','git push','secrets.']:
             self.assertNotIn(bad, wf)
         for needed in ['tools/release_audit.py','unittest discover','compileall','python -m build','twine check','tools/build_release_bundle.py','SHA256SUMS','Clean base install','Clean web install','actions/upload-artifact@v4']:


### PR DESCRIPTION
### Motivation
- The release-candidate workflow was failing with `TypeError: create_app() missing 1 required positional argument: 'runs_root'` because the installed-wheel smoke invoked `create_app()` with no argument. 
- The smoke test must run the packaged wheel outside the repository, provide an explicit temporary runs root, and verify the packaged health endpoint and static assets without starting a live server. 
- Provide regression coverage so the workflow cannot silently revert to calling `create_app()` with no runs root. 

### Description
- Updated `.github/workflows/release-candidate.yml` to replace the bare `TestClient(create_app())` block with a `TemporaryDirectory` usage that creates an explicit `runs` subdirectory, passes that `runs_root` to `create_app(runs_root)`, and asserts `/api/health` (exact JSON), `/` (200), `/static/app.css` (200), and `/static/app.js` (200). 
- Extended `tests/test_release_readiness.py` to parse the workflow and assert the presence of `TemporaryDirectory`, explicit `runs_root` creation and `runs_root.mkdir()`, a call to `create_app(runs_root)`, absence of a bare `create_app()` call, presence of the health and static checks, absence of Uvicorn/`0.0.0.0` startup, and retention of `contents: read` and `workflow_dispatch` only. 
- Did not change `outrider/web_app.py`, did not weaken the `create_app` signature, and did not alter versions, packaged contents, skills, or schemas. 

### Testing
- Ran `python tools/release_audit.py` and `python tools/release_audit.py --json`, both completed and reported overall status `ready`. 
- Ran unit tests with `python -m unittest discover -s tests -p "test_*.py"`, which executed 94 tests with 4 skipped and all passed. 
- Ran `python -m compileall outrider tests mcp-server tools` which completed successfully. 
- Attempted `python -m build` and `python -m pip install --upgrade build twine` and the clean installed-wheel FastAPI smoke locally, but installation of `build`/`twine`/`fastapi` failed due to package-index/network restrictions (tunnel/403), so `build`, `twine check dist/*`, and the external clean-wheel smoke run could not be completed locally. 
- Confirmed `create_app` signature and runtime behavior were not changed and that Python package version `0.2.0` and plugin/content version `3.0.1` remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5470d2e7548330a4e82553d53a49eb)