### PR TITLE
docs: finalize published 0.2.0 and 3.0.1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-No unreleased changes.
+### Documentation
+
+- Updated public documentation after publication of the Python 0.2.0 and Claude plugin/content 3.0.1 GitHub releases, including release links, installation guidance, checksum instructions, and implementation-status corrections.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,31 @@ Outrider uses independent version domains. The Python package remains `0.2.0`; t
 
 The base Python package installs the deterministic local controls and CLI with PyYAML only. Web review support is optional via the `web` extra, and MCP server dependencies are installed separately from `mcp-server/requirements.txt` in a source checkout.
 
-## Current repository release candidates
+## Current releases
 
-Prepared release versions in this repository are Python package release candidate: 0.2.0 and Claude plugin/content release candidate: 3.0.1. Individual skill versions remain independent, and JSON schema versions remain at `1`. These candidates are not published releases until maintainers create tags, GitHub release records, and any optional PyPI publication.
+Python 0.2.0 is published as a GitHub release under tag `python-v0.2.0`: <https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0>. Claude plugin/content 3.0.1 is published as a GitHub release under tag `plugin-v3.0.1`: <https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1>. These tags identify independent version domains; individual skill versions remain independent, and JSON contract schemas remain version `1`. PyPI publication is not claimed, and Claude Marketplace publication is not claimed.
 
-Release-readiness commands:
+Python release artifacts:
+
+- `outrider_recon-0.2.0-py3-none-any.whl`
+- `outrider_recon-0.2.0.tar.gz`
+- `SHA256SUMS`
+
+Plugin/content release artifacts:
+
+- `outrider-recon-bundle-3.0.1.zip`
+- `SHA256SUMS`
+
+The shared `SHA256SUMS` file covers all three release artifacts across both release domains. Published GitHub release artifacts remain checksum-verifiable, but this repository does not claim cryptographic signing.
+
+Release-readiness commands for future work:
 
 ```bash
 python tools/release_audit.py
 python tools/build_release_bundle.py --output-dir dist --source-date-epoch 1783900800
 ```
 
-The manual `release-candidate.yml` workflow can be triggered through GitHub Actions `workflow_dispatch` to build unsigned candidate artifacts. Publication remains a maintainer action.
+The manual `release-candidate.yml` workflow remains available through GitHub Actions `workflow_dispatch` for future releases. It builds unsigned candidate artifacts for maintainer review only and does not publish automatically.
 
 ## Optional MCP policy enforcement
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,13 +5,13 @@
 This document describes both implemented behavior and architectural design intent. The current implementation is intentionally split across separate domains:
 
 - **Claude plugin/content release**: Implemented as the skill bundle, plugin manifest, docs, examples, install scripts, and optional MCP companion listed in the changelog. Version source: `CHANGELOG.md` and `.claude-plugin/plugin.json`. This release domain tracks the packaged Claude-facing content.
-- **Python CLI package**: Implemented as run-folder scaffolding, deterministic scope validation, stable run manifests, append-only workflow-state events, validated state transitions, append-only evidence registration, SHA-256 artifact integrity verification, append-only approval records, and bounded offline action-policy decisions. Version source: `pyproject.toml` and `outrider/__init__.py`. The CLI validates local scope, workflow state, approvals, and evidence integrity; the optional MCP server enforces tool-boundary policy for the existing five enrichment tools. It does not implement recon orchestration, authenticated approvers, finding validation, Claude skill-contract enforcement, automatic evidence capture, or concurrent-writer protection.
+- **Python CLI package**: Implemented as run-folder scaffolding, deterministic scope validation, stable run manifests, append-only workflow-state events, validated state transitions, append-only evidence registration, SHA-256 artifact integrity verification, append-only approval records, and bounded offline action-policy decisions. Version source: `pyproject.toml` and `outrider/__init__.py`. The CLI validates local scope, workflow state, approvals, evidence integrity, skill request/result contracts, and human-reviewed finding promotion; the optional MCP server enforces tool-boundary policy for the existing five enrichment tools. It does not implement autonomous recon orchestration, authenticated approvers, automatic evidence capture from every skill, unrestricted skill execution, or concurrent-writer protection.
 - **Individual skill frontmatter**: Implemented per `skills/*/SKILL.md`. Version source: each skill's YAML `version:` field. Skill versions may differ from the plugin/content release and from the Python package version.
 - **MCP server**: Implemented as optional live enrichment. Version source: MCP server files and dependency metadata. The MCP server provides five live enrichment tools and enforces explicit run context, fixed action mappings, scope, workflow-state, and approval decisions before HTTP or DNS activity.
 
 These version domains do not have to use the same number. A plugin/content release can advance independently from the Python CLI package, individual skill frontmatter, or MCP implementation.
 
-The asset graph, output schema, sidecar coordination, validator discipline, and approval/scope concepts below are the intended architecture. Some are implemented as Claude skill instructions and documentation today; deterministic Python enforcement now covers scope validation, workflow-state validation, evidence integrity, approval/action-policy decisions, and MCP tool-boundary enforcement where explicitly described in code. Skill-contract enforcement, authenticated approvers, finding validation, recon orchestration, automatic evidence capture, concurrent-writer protection, and a web UI are not implemented.
+The asset graph, output schema, sidecar coordination, validator discipline, and approval/scope concepts below are the intended architecture. Deterministic Python controls now implement scope validation, stable run manifests, workflow-state events and transitions, evidence registration and integrity verification, approval records and action-policy evaluation, MCP tool-boundary enforcement, skill request/result contract creation and validation, deterministic human-reviewed finding promotion and verification, the packaged skill catalog and schemas, and optional local loopback-only read-only web review. Still not implemented: autonomous recon orchestration by the Python CLI, authenticated approver identity, automatic evidence capture from every skill, unrestricted skill execution by Python, concurrent multi-writer coordination, public or authenticated web deployment, or artifact download/mutation through the web plane. Skills cannot self-certify `validated_finding`; human reviewer attribution is recorded metadata, not authenticated identity.
 
 ## The router + sub-skill split
 
@@ -220,7 +220,7 @@ For individual skills:
 - **MINOR** — new sections, new techniques, expanded catalogs.
 - **PATCH** — typo fixes, link updates, severity-tier corrections.
 
-The prepared plugin/content release candidate is v3.0.1. The Python CLI package and individual skill versions are separate domains and may use different numbers.
+The published plugin/content GitHub release is v3.0.1. The Python CLI package and individual skill versions are separate domains and may use different numbers.
 
 ## Renumbering policy
 
@@ -340,7 +340,7 @@ The contract layer does not implement automatic skill execution, automatic evide
 
 Outrider implements deterministic scope validation, durable run identity and workflow state, evidence integrity, approval policy evaluation, MCP boundary enforcement, skill request/result contracts, and append-only evidence-backed finding promotion. Finding promotion records human-reviewed `validated_finding` entries in `findings.jsonl` with source-result SHA-256 provenance, source-claim snapshots, current-scope checks at promotion time, and local evidence verification.
 
-The architecture does not implement automatic vulnerability validation, exploitation, automatic candidate promotion, finding lifecycle updates, automatic Markdown rendering, client acceptance workflow, authenticated reviewers, concurrent-writer protection.
+The architecture does not implement automatic vulnerability validation, exploitation, automatic candidate promotion, finding lifecycle updates, automatic Markdown rendering, client acceptance workflow, authenticated reviewer identity, concurrent-writer protection.
 
 ## Local web review plane
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,25 +23,74 @@ The MCP server is optional -- all skills work without it.
 
 ## Python package installation
 
-The Python package version is `0.2.0` and is independent of the Claude plugin/content version `3.0.1`. Install the base CLI from a source checkout with:
+The Python package version is `0.2.0` and is independent of the Claude plugin/content version `3.0.1`.
+
+### Install from the published GitHub release wheel
+
+1. Open the Python 0.2.0 GitHub release page: <https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0>.
+2. Download `outrider_recon-0.2.0-py3-none-any.whl` into an artifact directory.
+3. Install the downloaded base wheel:
+
+```bash
+python -m pip install ./outrider_recon-0.2.0-py3-none-any.whl
+```
+
+4. To install optional local web review dependencies from the downloaded wheel, run:
+
+```bash
+python -m pip install "./outrider_recon-0.2.0-py3-none-any.whl[web]"
+```
+
+5. Verify the installed version:
+
+```bash
+outrider --version
+python -m outrider --version
+```
+
+The release documentation does not claim PyPI publication for `outrider-recon==0.2.0`.
+
+### Install from a source checkout
+
+From a repository checkout, install the base CLI with:
 
 ```bash
 python -m pip install .
 ```
 
-The base installation provides deterministic local controls and does not install FastAPI, Uvicorn, httpx, or the MCP SDK. To install the optional local read-only web review plane, use:
+The base installation provides deterministic local run, scope, state, evidence, approval, action-policy, contract, finding, and review controls. It does not install FastAPI, Uvicorn, httpx, or the MCP SDK, and it does not execute the recon methodology itself. To install the optional local read-only web review plane from a source checkout, use:
 
 ```bash
 python -m pip install ".[web]"
 ```
 
-To use the optional MCP server from a source checkout, install its dependencies separately:
+### Optional MCP server from source checkout
+
+The optional MCP server calls the Python control layer and enforces run context, scope, state, and approval policy before the existing live enrichment operations. Denied MCP decisions perform no HTTP or DNS request. Install its dependencies separately from a source checkout:
 
 ```bash
 python -m pip install -r mcp-server/requirements.txt
 ```
 
 Re-running `install.sh` updates the Claude skill symlinks from the current repository content. The `_shared` directory is support material and is not installed as a twelfth skill.
+
+### Plugin/content release bundle
+
+Open the plugin/content 3.0.1 GitHub release page: <https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1>. Download `outrider-recon-bundle-3.0.1.zip`, verify the relevant checksum entry, extract it into a review directory, inspect `RELEASE-MANIFEST.json`, and then follow the Claude skill installation method for your Claude surface. No Claude Marketplace publication is claimed.
+
+If only the plugin bundle is present in your artifact directory, verify just that checksum entry:
+
+```bash
+grep 'outrider-recon-bundle-3.0.1.zip' SHA256SUMS | sha256sum -c -
+```
+
+If only the Python artifacts are present, verify just the Python entries:
+
+```bash
+grep -E 'outrider_recon-0.2.0-py3-none-any.whl|outrider_recon-0.2.0.tar.gz' SHA256SUMS | sha256sum -c -
+```
+
+An unfiltered `sha256sum -c SHA256SUMS` expects every artifact named in the shared checksum file to exist in the current artifact directory.
 
 ## Claude Code (CLI)
 
@@ -171,8 +220,8 @@ Edit `skills/<skill-name>/SKILL.md` directly. All files are plain Markdown. You 
 The Claude skill/plugin bundle and the Python CLI package are separate installation concerns:
 
 - The one-click and manual Claude Code flows install the skill bundle into `~/.claude/skills/` so Claude can load the methodology and sub-skills.
-- The Python package exposes the `outrider` console script for run-folder scaffolding. The current CLI initializes and inspects run folders; it does not currently execute recon or enforce scope.
-- The optional MCP server is installed separately from `mcp-server/requirements.txt` and adds live enrichment tools. It does not currently enforce scope by itself.
+- The Python package exposes the `outrider` console script for deterministic local run, scope, state, evidence, approval, action-policy, contract, finding, and review controls. It does not execute the recon methodology itself.
+- The optional MCP server is installed separately from `mcp-server/requirements.txt` and adds live enrichment tools. It calls the Python control layer before live operations and denied decisions perform no HTTP or DNS request.
 
 ## Verifying versions
 
@@ -206,14 +255,3 @@ rm -rf ~/.claude/skills/analysis-and-reporting \
 ```
 
 Or remove the symlinks if you used method 2 above.
-
-## Local release-candidate artifacts
-
-After maintainers build candidates, install the local Python wheel without claiming PyPI publication:
-
-```bash
-python -m pip install outrider_recon-0.2.0-py3-none-any.whl
-python -m pip install "outrider_recon-0.2.0-py3-none-any.whl[web]"
-```
-
-Verify the plugin/content bundle separately by inspecting `outrider-recon-bundle-3.0.1.zip` and `RELEASE-MANIFEST.json`. Candidate artifacts are unsigned until a maintainer publishes official release records.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,13 +35,13 @@ The Python package version is `0.2.0` and is independent of the Claude plugin/co
 python -m pip install ./outrider_recon-0.2.0-py3-none-any.whl
 ```
 
-4. To install optional local web review dependencies from the downloaded wheel, run:
+1. To install optional local web review dependencies from the downloaded wheel, run:
 
 ```bash
 python -m pip install "./outrider_recon-0.2.0-py3-none-any.whl[web]"
 ```
 
-5. Verify the installed version:
+1. Verify the installed version:
 
 ```bash
 outrider --version

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -4,7 +4,6 @@
 - **Audited commit:** 57b452d4688cac280f17f3d35867e9129dc3706e plus this audit branch's committed changes
 - **Overall status:** ready_with_limitations
 
-
 ## Post-release status
 
 After the historical audit below, maintainers completed the release from commit `2ff9db995e7d2cb78024cbeea09bf526888626da`. Python `0.2.0` is published as GitHub release tag `python-v0.2.0` (<https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0>), and Claude plugin/content `3.0.1` is published as GitHub release tag `plugin-v3.0.1` (<https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1>). Both tags point to the release commit.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -4,6 +4,13 @@
 - **Audited commit:** 57b452d4688cac280f17f3d35867e9129dc3706e plus this audit branch's committed changes
 - **Overall status:** ready_with_limitations
 
+
+## Post-release status
+
+After the historical audit below, maintainers completed the release from commit `2ff9db995e7d2cb78024cbeea09bf526888626da`. Python `0.2.0` is published as GitHub release tag `python-v0.2.0` (<https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0>), and Claude plugin/content `3.0.1` is published as GitHub release tag `plugin-v3.0.1` (<https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1>). Both tags point to the release commit.
+
+Maintainer verification confirmed successful checksum verification for `outrider_recon-0.2.0-py3-none-any.whl`, `outrider_recon-0.2.0.tar.gz`, and `outrider-recon-bundle-3.0.1.zip`; successful clean base-wheel installation; successful optional web installation; and installed-wheel FastAPI TestClient checks for `/api/health`, `/`, `/static/app.css`, and `/static/app.js`. PyPI publication is not claimed. Claude Marketplace publication is not claimed. Published artifacts are checksum-verifiable but are not claimed to be cryptographically signed.
+
 ## Supported execution modes
 
 | Mode | Status | Notes |
@@ -55,7 +62,7 @@ Status: **ready_with_limitations**. Unit tests continue on Python 3.10 and 3.11,
 
 ## Known limitations
 
-- The Python package is still `0.2.0` and should be treated as pre-release until a dedicated version/release PR updates metadata.
+- The Python package remains pre-1.0 at `0.2.0`; this does not claim stable post-1.0 API guarantees.
 - The MCP server is a source-checkout companion, not a separately published wheel component.
 - The web review plane has no authentication and is intended for loopback-only local review.
 - Claude skill capabilities are methodology/content capabilities; they are not equivalent to autonomous execution in the Python CLI.
@@ -75,7 +82,7 @@ None identified after this audit. Remaining items are release limitations, not b
 
 ## Release recommendation
 
-**ready_with_limitations:** a version/release PR may proceed after acknowledging the limitations above and after all GitHub Actions jobs pass.
+**historical recommendation completed:** the version/release preparation proceeded, and maintainers subsequently published the GitHub releases described in the post-release status above. Future release PRs should acknowledge current limitations and wait for all GitHub Actions jobs to pass.
 
 ## Historical version-domain recommendation (applied by release preparation)
 
@@ -84,12 +91,12 @@ None identified after this audit. Remaining items are release limitations, not b
 - **Individual skills:** **no version change** is recommended for this audit because skill content semantics are unchanged.
 - **JSON schemas:** **no version change** is recommended because schema semantics remain version `1`.
 
-## Applied version decision for release preparation
+## Historical applied version decision for release preparation
 
-- Python package `0.2.0` is applied as a minor pre-1.0 release candidate for backward-compatible deterministic control-plane functionality.
-- Claude plugin/content `3.0.1` is applied as a patch release candidate for metadata and documentation truth corrections.
+- Python package `0.2.0` was applied as a minor pre-1.0 release candidate for backward-compatible deterministic control-plane functionality during release preparation; it was subsequently published as the GitHub release noted above.
+- Claude plugin/content `3.0.1` was applied as a patch release candidate for metadata and documentation truth corrections during release preparation; it was subsequently published as the GitHub release noted above.
 - Individual skill frontmatter versions are unchanged.
 - Manifest, state-event, evidence, approval, skill-request, skill-result, and finding schemas remain at version `1`.
 - Deterministic candidate artifacts can be built locally or through the manual unsigned release-candidate workflow.
-- No Git tags, GitHub releases, PyPI publication, or Claude plugin publication have occurred in this preparation PR.
+- At the time of the preparation PR, release tags and release records had not yet been created; maintainers later created the two GitHub release records described in the post-release status. PyPI publication and Claude Marketplace publication are still not claimed.
 - Status remains **ready_with_limitations** because MCP is source-checkout based, the web plane is loopback-only and unauthenticated, and publication is manual.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -2,23 +2,63 @@
 
 Outrider uses independent version domains:
 
-- Python package release candidates use the Python distribution version.
-- Claude plugin/content release candidates use `.claude-plugin/plugin.json`.
-- Individual skill frontmatter versions are skill-local and do not change for Python 0.2.0 / plugin 3.0.1.
-- Runtime JSON schemas remain schema version 1.
+- Python package releases use the Python distribution version.
+- Claude plugin/content releases use `.claude-plugin/plugin.json`.
+- Individual skill frontmatter versions are skill-local and did not change for Python 0.2.0 / plugin 3.0.1.
+- Runtime JSON schemas and the release manifest schema remain schema version 1.
 
-No automatic publication is performed by the release-candidate workflow. Candidate artifacts are unsigned build outputs for maintainer review.
+## Current published GitHub releases
 
-## Recommended tag namespaces
+The maintainer-operated 2026-07-13 releases are published as GitHub release records from release commit `2ff9db995e7d2cb78024cbeea09bf526888626da`:
 
-No existing repository tag convention establishes a safe independent version-domain scheme. Use unambiguous future tags after verification:
+- Python package `0.2.0`: tag `python-v0.2.0`, release page <https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0>.
+- Claude plugin/content `3.0.1`: tag `plugin-v3.0.1`, release page <https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1>.
 
-- Python: `python-v0.2.0`
-- Plugin/content: `plugin-v3.0.1`
+The two tags identify separate release domains even though both tags point to the same accepted release commit. PyPI publication is not claimed. Claude Marketplace publication is not claimed.
 
-Do not create these tags until the manual release checklist is complete.
+## Published artifact assignments
 
-## Release order
+Python release artifacts:
+
+- `outrider_recon-0.2.0-py3-none-any.whl`
+- `outrider_recon-0.2.0.tar.gz`
+- `SHA256SUMS`
+
+Plugin/content release artifacts:
+
+- `outrider-recon-bundle-3.0.1.zip`
+- `SHA256SUMS`
+
+The same `SHA256SUMS` file covers all three release artifacts across the two release domains. If all artifacts from both release pages are downloaded into one artifact directory, run:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+If only the plugin bundle is downloaded, filter to that entry so `sha256sum` does not report the missing Python artifacts:
+
+```bash
+grep 'outrider-recon-bundle-3.0.1.zip' SHA256SUMS | sha256sum -c -
+```
+
+If only the Python wheel and sdist are downloaded, filter to those entries so `sha256sum` does not report the missing plugin bundle:
+
+```bash
+grep -E 'outrider_recon-0.2.0-py3-none-any.whl|outrider_recon-0.2.0.tar.gz' SHA256SUMS | sha256sum -c -
+```
+
+An unfiltered `sha256sum -c SHA256SUMS` expects every filename in the checksum file to exist in the current artifact directory.
+
+## Tag namespaces
+
+Current independent tag namespaces are:
+
+- Python: `python-v<python-version>` such as `python-v0.2.0`.
+- Plugin/content: `plugin-v<plugin-version>` such as `plugin-v3.0.1`.
+
+For future releases, select unambiguous future tags only after the manual release checklist is complete. Do not reuse or move existing tags.
+
+## Future release order
 
 1. Build and verify unsigned candidates from the selected commit.
 2. Create the Python tag if the Python artifacts are accepted.
@@ -26,12 +66,9 @@ Do not create these tags until the manual release checklist is complete.
 4. Create GitHub release records and attach only the matching artifacts.
 5. Optionally publish Python artifacts to PyPI as a separate maintainer action.
 
-## Artifact naming
+## Manual candidate workflow
 
-- `outrider_recon-0.2.0-py3-none-any.whl`
-- `outrider_recon-0.2.0.tar.gz`
-- `outrider-recon-bundle-3.0.1.zip`
-- `SHA256SUMS`
+The manual workflow is `release-candidate.yml` and is triggered with `workflow_dispatch` only. It produces unsigned review outputs for maintainers, keeps `contents: read` permissions, and does not automatically tag, publish GitHub releases, upload to PyPI, or publish to any Claude marketplace. Published GitHub release artifacts remain checksum-verifiable; this repository does not claim cryptographic signing for them.
 
 ## Verification commands
 
@@ -42,5 +79,3 @@ python -m twine check dist/*
 python tools/build_release_bundle.py --output-dir dist --source-date-epoch 1783900800
 sha256sum -c dist/SHA256SUMS
 ```
-
-The manual workflow is `release-candidate.yml` and is triggered with `workflow_dispatch` only.

--- a/docs/releases/plugin-3.0.1.md
+++ b/docs/releases/plugin-3.0.1.md
@@ -1,6 +1,12 @@
 # Claude plugin/content 3.0.1 release notes
 
-Claude plugin/content 3.0.1 is a patch release candidate for the existing 3.0 methodology and capability set. It corrects metadata and documentation boundaries without changing individual skill methodology.
+Claude plugin/content 3.0.1 is a published GitHub release for the existing 3.0 methodology and capability set. It corrects metadata and documentation boundaries without changing individual skill methodology.
+
+- Release tag: `plugin-v3.0.1`
+- Release page: <https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1>
+- Release commit: `2ff9db995e7d2cb78024cbeea09bf526888626da`
+- Published artifact: `outrider-recon-bundle-3.0.1.zip`
+- Shared checksum artifact: `SHA256SUMS`
 
 ## Scope of the patch
 
@@ -8,11 +14,16 @@ Claude plugin/content 3.0.1 is a patch release candidate for the existing 3.0 me
 - The bundle documents 11 shipped skills; `skills/_shared` is shared guidance and is not counted as a twelfth skill.
 - The existing capability count is unchanged.
 - Individual skill frontmatter versions did not change.
-- Python 0.2.0 is a separate version domain.
+- Python 0.2.0 is a separate version domain and no PyPI publication is implied by this plugin/content release.
+- No Claude Marketplace publication is claimed.
+
+## Published release verification
+
+A GitHub release exists for `plugin-v3.0.1`. Maintainer verification confirmed checksum verification for `outrider-recon-bundle-3.0.1.zip` and accepted the `RELEASE-MANIFEST.json` contents for the 11-skill bundle.
 
 ## Structured-run guidance
 
-Skills continue to use shared structured-run contract guidance. Discovery signals do not expand scope, and skills may produce `finding_candidate` records but must not claim Python-validated findings.
+Skills continue to use shared structured-run contract guidance. Discovery signals do not expand scope, and skills may produce `finding_candidate` records but must not claim Python-validated findings. Skills cannot self-certify `validated_finding` records.
 
 ## Deterministic-control relationship
 
@@ -28,20 +39,28 @@ The optional local web plane is read-only, loopback-oriented review UI for local
 
 ## Installation and update
 
-Use the plugin/content bundle artifact:
+Download the plugin/content bundle from the 3.0.1 GitHub release page:
 
 - `outrider-recon-bundle-3.0.1.zip`
 
-Extract it into a review directory, inspect `RELEASE-MANIFEST.json`, and follow the repository installation guide. Do not treat the unsigned candidate as an official release until maintainers create the appropriate tags and release records.
+Extract it into a review directory, inspect `RELEASE-MANIFEST.json`, and follow the repository installation guide for the Claude surface you use.
 
 ## Known limitations
 
-- Candidate artifacts are unsigned.
-- No Git tag, GitHub release, PyPI upload, or plugin publication is performed by this preparation PR.
+- Published artifacts are checksum-verifiable but are not claimed to be cryptographically signed.
 - MCP remains a source-checkout companion.
+- No Claude Marketplace publication is claimed.
 
 ## Checksum verification
 
+The same `SHA256SUMS` file covers all three artifacts across the Python and plugin/content release domains. If all artifacts from both release pages are present in the current artifact directory, run:
+
 ```bash
 sha256sum -c SHA256SUMS
+```
+
+If only the plugin bundle is present, filter to the bundle entry so the Python artifacts are not reported as missing:
+
+```bash
+grep 'outrider-recon-bundle-3.0.1.zip' SHA256SUMS | sha256sum -c -
 ```

--- a/docs/releases/python-0.2.0.md
+++ b/docs/releases/python-0.2.0.md
@@ -1,6 +1,22 @@
 # Python 0.2.0 release notes
 
-Python 0.2.0 is a minor pre-1.0 release candidate for the Outrider Python control plane. It adds substantial backward-compatible functionality without claiming API stability beyond pre-1.0 expectations.
+Python 0.2.0 is a minor pre-1.0 GitHub release for the Outrider Python control plane. It adds substantial backward-compatible functionality without claiming stable post-1.0 API guarantees.
+
+- Release tag: `python-v0.2.0`
+- Release page: <https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0>
+- Release commit: `2ff9db995e7d2cb78024cbeea09bf526888626da`
+- Published artifacts: `outrider_recon-0.2.0-py3-none-any.whl`, `outrider_recon-0.2.0.tar.gz`, and `SHA256SUMS`
+
+## Verification results
+
+Maintainer verification confirmed that checksum verification passed for the wheel and source distribution, the base wheel installed successfully in a clean Python 3.12 environment, and both commands reported `outrider-recon 0.2.0`:
+
+```bash
+outrider --version
+python -m outrider --version
+```
+
+The optional web installation also succeeded in a clean environment, and installed-wheel FastAPI TestClient checks passed for `/api/health`, `/`, `/static/app.css`, and `/static/app.js`.
 
 ## Major features
 
@@ -17,35 +33,35 @@ Python 0.2.0 is a minor pre-1.0 release candidate for the Outrider Python contro
 
 ## Security and control boundaries
 
-Python remains authoritative for deterministic scope, state, evidence, approval, action-policy, contract, and finding promotion checks. Denied MCP requests must not perform live network or DNS activity.
+Python remains authoritative for deterministic scope, state, evidence, approval, action-policy, contract, and finding promotion checks. Denied MCP requests must not perform live network or DNS activity. Python does not execute the recon methodology itself.
 
-## Installation from local artifacts
+## Installation from GitHub release artifacts
 
-Base install from a downloaded wheel:
-
-```bash
-python -m pip install outrider_recon-0.2.0-py3-none-any.whl
-```
-
-Optional web review dependencies from a downloaded wheel:
+Download the wheel from the Python 0.2.0 GitHub release page into an artifact directory, then install it directly:
 
 ```bash
-python -m pip install "outrider_recon-0.2.0-py3-none-any.whl[web]"
+python -m pip install ./outrider_recon-0.2.0-py3-none-any.whl
 ```
 
-This release note does not claim that `outrider-recon==0.2.0` has been published to PyPI.
+Optional web review dependencies can be installed from the downloaded wheel with:
+
+```bash
+python -m pip install "./outrider_recon-0.2.0-py3-none-any.whl[web]"
+```
+
+This release note does not claim PyPI availability for `outrider-recon==0.2.0`.
 
 ## MCP companion limitation
 
-The MCP server remains an optional source-checkout companion. It is not required for the base wheel and is not advertised as an installed console script in this candidate.
+The MCP server remains an optional source-checkout companion. It is not required for the base wheel and is not advertised as an installed console script.
 
 ## Supported Python versions
 
-The project CI covers Python 3.10, 3.11, and 3.12.
+The project CI covers Python 3.10, 3.11, and 3.12. Clean-install release verification was confirmed with Python 3.12.
 
 ## Upgrade notes from 0.1.0
 
-Upgrade local wheel installs by replacing the installed 0.1.0 wheel with the 0.2.0 candidate. Existing deterministic run-folder schemas remain version 1.
+Upgrade local wheel installs by replacing the installed 0.1.0 wheel with the downloaded 0.2.0 wheel. Existing deterministic run-folder schemas remain version 1.
 
 ## Compatibility notes
 
@@ -55,30 +71,21 @@ Upgrade local wheel installs by replacing the installed 0.1.0 wheel with the 0.2
 
 ## Known limitations
 
-- Release publication, Git tags, and GitHub release records are manual maintainer actions.
+- Future release publication, tags, and GitHub release records remain maintainer-operated actions.
 - Web review is loopback-only and unauthenticated; bind it only to trusted local interfaces.
 - MCP enrichment remains optional and source-checkout based.
-
-## Verification commands
-
-```bash
-outrider --version
-python -m outrider --version
-python tools/release_audit.py
-python -m twine check dist/*
-sha256sum -c dist/SHA256SUMS
-```
-
-## Artifact names
-
-- `outrider_recon-0.2.0-py3-none-any.whl`
-- `outrider_recon-0.2.0.tar.gz`
-- `SHA256SUMS`
+- Published artifacts are checksum-verifiable but are not claimed to be cryptographically signed.
 
 ## Checksum verification
 
-Place the artifacts and `SHA256SUMS` in the same directory, then run:
+The same `SHA256SUMS` file covers all three artifacts across the Python and plugin/content release domains. If all artifacts from both release pages are present in the current artifact directory, run:
 
 ```bash
 sha256sum -c SHA256SUMS
+```
+
+If only the Python artifacts are present, filter to the wheel and sdist entries so the plugin bundle is not reported as missing:
+
+```bash
+grep -E 'outrider_recon-0.2.0-py3-none-any.whl|outrider_recon-0.2.0.tar.gz' SHA256SUMS | sha256sum -c -
 ```

--- a/docs/releases/release-checklist.md
+++ b/docs/releases/release-checklist.md
@@ -1,60 +1,71 @@
 # Manual release checklist
 
-This checklist is for a future maintainer-operated release. This PR does not perform tagging, publication, GitHub release creation, PyPI upload, or plugin publication.
+This checklist is reusable for future maintainer-operated releases. The post-release documentation cleanup does not recreate releases, retag commits, replace artifacts, publish to external registries, or modify release records.
 
-## 1. Pre-tag verification
+## Completed release record: 2026-07-13
+
+- Python package `0.2.0` was released from commit `2ff9db995e7d2cb78024cbeea09bf526888626da` with tag `python-v0.2.0` and a GitHub release record.
+- Claude plugin/content `3.0.1` was released from the same commit with tag `plugin-v3.0.1` and a GitHub release record.
+- Published artifacts were accepted as `outrider_recon-0.2.0-py3-none-any.whl`, `outrider_recon-0.2.0.tar.gz`, `outrider-recon-bundle-3.0.1.zip`, and shared `SHA256SUMS`.
+- Checksum verification passed for all three release artifacts.
+- Clean base-wheel installation passed, and `outrider --version` plus `python -m outrider --version` reported `outrider-recon 0.2.0`.
+- Clean optional web installation passed, including installed-wheel FastAPI TestClient checks for `/api/health`, `/`, `/static/app.css`, and `/static/app.js`.
+- PyPI publication is not marked complete.
+- Claude Marketplace publication is not marked complete.
+
+## Future release checklist
+
+### 1. Pre-tag verification
 
 - Confirm the selected commit is on `main` and CI has passed.
 - Run `python tools/release_audit.py` and review limitations.
-- Confirm Python `0.2.0`, plugin/content `3.0.1`, 11 skills, and schema version 1.
+- Confirm the intended Python, plugin/content, skill, runtime schema, and release manifest schema versions.
 
-## 2. Build candidate artifacts
+### 2. Build unsigned candidate artifacts
 
 - Run the manual release-candidate workflow or build locally.
 - Build wheel, sdist, plugin/content bundle, and `SHA256SUMS`.
+- Treat workflow artifacts as unsigned maintainer-review outputs, not automatic publications.
 
-## 3. Inspect artifacts
+### 3. Inspect artifacts
 
 - Inspect wheel and sdist metadata.
-- Inspect `outrider-recon-bundle-3.0.1.zip` contents and `RELEASE-MANIFEST.json`.
+- Inspect the plugin/content zip contents and `RELEASE-MANIFEST.json`.
 - Confirm no tests, CI, caches, run data, credentials, or local artifacts are present.
 
-## 4. Verify checksums
+### 4. Verify checksums
 
-- Run `sha256sum -c SHA256SUMS` in the artifact directory.
+- Run `sha256sum -c SHA256SUMS` in the artifact directory when all artifacts are present.
+- Use filtered checksum commands when only one release domain's artifacts are present.
 
-## 5. Create Python tag
+### 5. Create release tags
 
-- After acceptance, create `python-v0.2.0` from the verified commit.
+- Create the Python tag from the verified commit only after Python artifacts are accepted.
+- Create the plugin/content tag from the verified commit only after the plugin/content bundle is accepted.
+- Do not move existing release tags for documentation-only follow-up commits.
 
-## 6. Create plugin/content tag
-
-- After acceptance, create `plugin-v3.0.1` from the verified commit.
-
-## 7. Create GitHub release or releases
+### 6. Create GitHub release records
 
 - Create release records after tags exist.
-- Mark candidates appropriately if not final.
+- Attach only the artifacts that match each release domain plus the shared checksum file.
 
-## 8. Attach correct artifacts
+### 7. Optional external publication
 
-- Attach Python artifacts to the Python release record.
-- Attach plugin/content bundle and checksums to the plugin/content release record.
-
-## 9. Optional PyPI publication
-
-- Publish only after maintainer approval using secure external publishing configuration.
+- Publish to PyPI only after maintainer approval using secure external publishing configuration.
+- Publish to any Claude marketplace only after maintainer approval and marketplace-specific verification.
 - Do not store credentials or tokens in repository files.
 
-## 10. Post-release installation verification
+### 8. Post-release installation verification
 
 - Install the published wheel in clean base and web environments.
-- Verify `outrider --version` reports `0.2.0`.
+- Verify CLI and module version commands.
+- Smoke-test installed optional web resources when web extras are published.
 
-## 11. Documentation verification
+### 9. Documentation verification
 
-- Confirm documentation no longer describes accepted artifacts as unpublished candidates once publication actually occurs.
+- Confirm documentation distinguishes published GitHub releases from future unsigned release-candidate builds.
+- Confirm PyPI and marketplace publication are claimed only if independently completed.
 
-## 12. Rollback response
+### 10. Rollback response
 
 - If a release error is found, document affected artifacts, remove or supersede broken release records as appropriate, and publish corrected artifacts from a new verified commit.

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -174,6 +174,56 @@ class ReleaseReadinessTests(unittest.TestCase):
         for needed in ['tools/release_audit.py','unittest discover','compileall','python -m build','twine check','tools/build_release_bundle.py','SHA256SUMS','Clean base install','Clean web install','actions/upload-artifact@v4']:
             self.assertIn(needed, wf)
 
+
+    def test_post_release_documentation_truth_alignment(self):
+        py_link = 'https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0'
+        plugin_link = 'https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1'
+        readme = (ROOT/'README.md').read_text()
+        self.assertIn('## Current releases', readme)
+        self.assertIn(py_link, readme)
+        self.assertIn(plugin_link, readme)
+        self.assertIn('does not publish automatically', readme)
+        release_index = (ROOT/'docs/releases/README.md').read_text()
+        self.assertIn('2ff9db995e7d2cb78024cbeea09bf526888626da', release_index)
+        self.assertIn('python-v0.2.0', release_index)
+        self.assertIn('plugin-v3.0.1', release_index)
+        self.assertIn('workflow_dispatch', release_index)
+        self.assertIn('does not automatically tag, publish GitHub releases, upload to PyPI', release_index)
+        py_notes = (ROOT/'docs/releases/python-0.2.0.md').read_text()
+        self.assertIn('minor pre-1.0 GitHub release', py_notes)
+        self.assertNotIn('minor pre-1.0 release candidate', py_notes)
+        self.assertIn(py_link, py_notes)
+        self.assertIn('This release note does not claim PyPI availability for `outrider-recon==0.2.0`.', py_notes)
+        plugin_notes = (ROOT/'docs/releases/plugin-3.0.1.md').read_text()
+        self.assertIn('published GitHub release', plugin_notes)
+        self.assertNotIn('patch release candidate', plugin_notes)
+        self.assertNotIn('Do not treat the unsigned candidate' + ' as an official release', plugin_notes)
+        self.assertIn(plugin_link, plugin_notes)
+        self.assertIn('No Claude Marketplace publication is claimed', plugin_notes)
+        readiness = (ROOT/'docs/release-readiness.md').read_text()
+        self.assertIn('## Post-release status', readiness)
+        self.assertIn('**Audit date:** 2026-07-13', readiness)
+        self.assertIn('**Audited commit:** 57b452d4688cac280f17f3d35867e9129dc3706e', readiness)
+        self.assertIn('historical recommendation completed', readiness)
+        checklist = (ROOT/'docs/releases/release-checklist.md').read_text()
+        self.assertIn('## Completed release record: 2026-07-13', checklist)
+        self.assertIn('PyPI publication is not marked complete', checklist)
+        self.assertIn('Claude Marketplace publication is not marked complete', checklist)
+        install = (ROOT/'docs/installation.md').read_text()
+        self.assertIn('python -m pip install ./outrider_recon-0.2.0-py3-none-any.whl', install)
+        self.assertIn('deterministic local run, scope, state, evidence, approval, action-policy, contract, finding, and review controls', install)
+        self.assertIn('Denied MCP decisions perform no HTTP or DNS request', install)
+        architecture = (ROOT/'docs/architecture.md').read_text()
+        self.assertIn('skill request/result contract creation and validation', architecture)
+        self.assertIn('deterministic human-reviewed finding promotion and verification', architecture)
+        self.assertIn('optional local loopback-only read-only web review', architecture)
+        self.assertNotIn('finding validation, Claude skill-contract enforcement', architecture)
+        self.assertNotIn('web UI are' + ' not implemented', architecture)
+        combined = '\n'.join((ROOT/p).read_text(errors='ignore') for p in ['README.md','docs/releases/README.md','docs/releases/python-0.2.0.md','docs/releases/plugin-3.0.1.md','docs/installation.md'])
+        self.assertIn('The same `SHA256SUMS` file covers all three', combined)
+        self.assertIn("grep 'outrider-recon-bundle-3.0.1.zip' SHA256SUMS | sha256sum -c -", combined)
+        self.assertIn("grep -E 'outrider_recon-0.2.0-py3-none-any.whl|outrider_recon-0.2.0.tar.gz' SHA256SUMS | sha256sum -c -", combined)
+
     def test_skill_and_schema_version_preservation(self):
         expected={
             'analysis-and-reporting': '1.0.0', 'cloud-and-infra': '1.1.0', 'identity-fabric': '1.0.0',

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -185,12 +185,57 @@ class Audit:
         if unexpected: self.warn('obvious secret-like patterns','review possible fixtures/false positives: '+', '.join(unexpected[:20]))
         else: self.ok('obvious secret-like patterns','no unexpected secret-like patterns found; documented fixtures/examples are allowlisted')
     def check_docs_versions(self):
-        text='\n'.join((self.root/p).read_text(errors='ignore') for p in ['README.md','docs/installation.md','docs/architecture.md','SECURITY.md','.claude-plugin/plugin.json','CHANGELOG.md'] if (self.root/p).exists())
-        if 'Python package release candidate: 0.2.0' in text or 'Python package release candidate `0.2.0`' in text or 'Python package `0.2.0`' in text:
-            if 'Claude plugin/content release candidate: 3.0.1' in text or 'Claude plugin/content release candidate `3.0.1`' in text or 'Claude plugin/content `3.0.1`' in text:
-                self.ok('documentation version-domain references','Python and Claude plugin versions are documented independently')
-                return
-        self.warn('documentation version-domain references','version-domain independence should be stated in public docs')
+        doc_paths = [
+            'README.md', 'docs/installation.md', 'docs/architecture.md', 'docs/release-readiness.md',
+            'docs/releases/README.md', 'docs/releases/python-0.2.0.md',
+            'docs/releases/plugin-3.0.1.md', 'docs/releases/release-checklist.md', 'CHANGELOG.md'
+        ]
+        docs = {p: (self.root / p).read_text(errors='ignore') for p in doc_paths if (self.root / p).exists()}
+        combined = '\n'.join(docs.values())
+        py_link = 'https://github.com/Ap6pack/outrider-recon/releases/tag/python-v0.2.0'
+        plugin_link = 'https://github.com/Ap6pack/outrider-recon/releases/tag/plugin-v3.0.1'
+        if py_link in combined and plugin_link in combined and 'python-v0.2.0' in combined and 'plugin-v3.0.1' in combined:
+            self.ok('published release documentation links','current docs link both GitHub release tags')
+        else:
+            self.fail('published release documentation links','missing release tag links or tag names')
+        stale_patterns = [
+            'Current repository release ' + 'candidates',
+            'These candidates are not ' + 'published releases',
+            'No Git tags, GitHub ' + 'releases',
+            'Do not create these tags ' + 'until',
+            'Do not treat the unsigned candidate ' + 'as an official release',
+            r'No Git tag, GitHub release',
+            'does not currently enforce scope ' + 'by itself',
+            'web UI are ' + 'not implemented',
+            'finding' + ' validation' + chr(46) + chr(42) + 'not' + ' implemented',
+            'skill-contract' + ' enforcement' + chr(46) + chr(42) + 'not' + ' implemented',
+        ]
+        hits=[]
+        for path, text in docs.items():
+            for pat in stale_patterns:
+                if re.search(pat, text, re.IGNORECASE): hits.append(f'{path}: {pat}')
+        if hits:
+            self.fail('stale release and implementation claims','; '.join(hits[:10]))
+        else:
+            self.ok('stale release and implementation claims','no stale unpublished-release or implementation-status claims detected')
+        forbidden_claims = [r'pip install outrider-recon==0\.2\.0', r'published to PyPI', r'PyPI publication is complete', r'Claude Marketplace publication is complete', r'published to Claude Marketplace']
+        hits=[pat for pat in forbidden_claims if re.search(pat, combined, re.IGNORECASE)]
+        if hits:
+            self.fail('external publication claim boundaries','unexpected PyPI or Claude Marketplace publication claim: '+', '.join(hits))
+        else:
+            self.ok('external publication claim boundaries','docs avoid PyPI and Claude Marketplace publication claims')
+        required = [
+            'unsigned candidate artifacts for maintainer review',
+            'does not publish automatically',
+            'The same `SHA256SUMS` file covers all three',
+            "grep 'outrider-recon-bundle-3.0.1.zip' SHA256SUMS | sha256sum -c -",
+            "grep -E 'outrider_recon-0.2.0-py3-none-any.whl|outrider_recon-0.2.0.tar.gz' SHA256SUMS | sha256sum -c -",
+        ]
+        missing=[term for term in required if term not in combined]
+        if missing:
+            self.fail('published-vs-candidate and checksum documentation','missing '+', '.join(missing))
+        else:
+            self.ok('published-vs-candidate and checksum documentation','docs distinguish published releases, future candidates, and shared SHA256SUMS behavior')
 
     def check_changelog(self):
         text=(self.root/'CHANGELOG.md').read_text(errors='ignore')


### PR DESCRIPTION
### Motivation

- Align public documentation and audit tooling with the maintainer-confirmed publication of Python `0.2.0` (tag `python-v0.2.0`) and Claude plugin/content `3.0.1` (tag `plugin-v3.0.1`) that both point to commit `2ff9db995e7d2cb78024cbeea09bf526888626da` and to remove stale "candidate"/unpublished wording while preserving the candidate workflow for future releases.  
- Correct implementation-status drift in docs where the repository previously understated implemented deterministic Python/MCP controls (scope, manifests, contracts, finding promotion, web review) without changing any runtime code, versions, tags, or artifacts.

### Description

- Replaced the README candidate-status section with a `## Current releases` section linking the two GitHub release pages and listing the published artifacts and shared `SHA256SUMS` behavior.  
- Updated release documentation under `docs/releases/` to record published-release facts and to keep the manual unsigned candidate workflow as guidance (`docs/releases/README.md`, `docs/releases/python-0.2.0.md`, `docs/releases/plugin-3.0.1.md`, `docs/releases/release-checklist.md`).  
- Corrected installation and implementation-status wording in `docs/installation.md`, `docs/architecture.md`, and `docs/release-readiness.md` to reflect implemented deterministic controls and to provide explicit wheel-install and filtered checksum instructions.  
- Extended `tools/release_audit.py` to assert presence of release links, detect and fail on remaining stale unpublished-release or incorrect publication claims, and to verify the shared `SHA256SUMS` documentation; added a unit test `test_post_release_documentation_truth_alignment` to `tests/test_release_readiness.py`.  
- Kept constraints: no runtime source changes, no version bumps in `pyproject.toml` or `.claude-plugin/plugin.json`, no tag/release/attachment modifications, and no artifact rebuilds or publication actions.  

### Testing

- Ran `python tools/release_audit.py` and `python tools/release_audit.py --json`; both completed with overall status `ready` (PASS).  
- Ran unit tests: `python -m unittest discover -s tests -p "test_*.py"` — 95 tests run, 4 skipped, all assertions passed (OK).  
- Ran static checks and packaging-related validations: `python -m compileall outrider tests mcp-server tools` (PASS) and JSON schema/manifest checks via `python -m json.tool` for `.claude-plugin/plugin.json` and the three contract schemas (PASS).  
- Ran `git diff --check` and repository checks; no outstanding diffs remained (PASS).  

Interpreter used for tests: `/root/.pyenv/versions/3.12.13/bin/python`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a547e85b0908330802a0512b08a30ff)