### PR TITLE
ci: separate core and web test coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,8 +90,8 @@ jobs:
           scandir: .
           additional_files: install.sh uninstall.sh
 
-  python-cli-tests:
-    name: Python CLI tests (${{ matrix.python-version }})
+  python-core-tests:
+    name: Python core tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -107,11 +107,32 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
-      - name: Install local package
-        run: python -m pip install -e ".[web]"
-      - name: Compile package, tests, and MCP server
-        run: python -m compileall outrider tests mcp-server
+      - name: Install base package
+        run: python -m pip install -e .
+      - name: Compile package, tests, MCP server, and tools
+        run: python -m compileall outrider tests mcp-server tools
       - name: Run complete unit test suite
+        run: python -m unittest discover -s tests -p "test_*.py"
+
+  web-control-tests:
+    name: Web control-plane tests (3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install package with web extra
+        run: python -m pip install -e ".[web]"
+      - name: Verify optional web dependencies
+        run: python -c "import fastapi, httpx, uvicorn"
+      - name: Compile package, tests, and tools
+        run: python -m compileall outrider tests tools
+      - name: Run focused web tests
+        run: python -m unittest tests.test_web_view tests.test_web_app
+      - name: Run complete unit test suite with web extra
         run: python -m unittest discover -s tests -p "test_*.py"
 
   release-readiness:
@@ -176,5 +197,25 @@ jobs:
               venv.EnvBuilder(with_pip=True).create(env)
               py = env / 'bin' / 'python'
               subprocess.check_call([py, '-m', 'pip', 'install', f'{wheel}[web]'])
-              subprocess.check_call([py, '-c', 'from outrider.web_app import create_app; from fastapi.testclient import TestClient; from outrider.package_resources import web_static_path; app=create_app("."); c=TestClient(app); assert c.get("/api/health").status_code == 200; assert c.get("/").status_code == 200; assert c.get("/static/app.css").status_code == 200; assert c.get("/static/app.js").status_code == 200; assert web_static_path("index.html").exists()'])
+              import textwrap
+              smoke = textwrap.dedent('''
+                  from pathlib import Path
+                  from tempfile import TemporaryDirectory
+                  from fastapi.testclient import TestClient
+                  from outrider.package_resources import web_static_path
+                  from outrider.web_app import create_app
+                  with TemporaryDirectory() as td:
+                      runs_root = Path(td) / "runs"
+                      runs_root.mkdir()
+                      client = TestClient(create_app(runs_root, control_token="fixture"))
+                      health = client.get("/api/health")
+                      assert health.status_code == 200
+                      assert health.json()["mode"] == "limited-control"
+                      assert client.get("/api/session").status_code == 200
+                      assert client.get("/").status_code == 200
+                      assert client.get("/static/app.css").status_code == 200
+                      assert client.get("/static/app.js").status_code == 200
+                      assert web_static_path("index.html").exists()
+              ''')
+              subprocess.check_call([py, '-c', smoke])
           PY

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -83,9 +83,12 @@ jobs:
               assert health.json() == {
                   "ok": True,
                   "service": "outrider-web",
-                  "mode": "read-only",
+                  "mode": "limited-control",
                   "network_scope": "loopback-only",
               }
+
+              session = client.get("/api/session")
+              assert session.status_code == 200
 
               assert client.get("/").status_code == 200
               assert client.get("/static/app.css").status_code == 200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added the first guarded web mutation capability: process-local-token-protected workflow-state transitions that reuse the deterministic Python state policy.
 
+### Changed
+
+- Split base Python compatibility testing from the optional web control-plane integration suite so web behavior is tested once on Python 3.12 while core compatibility remains covered on Python 3.10–3.12.
+
 ### Documentation
 
 - Updated public documentation after publication of the Python 0.2.0 and Claude plugin/content 3.0.1 GitHub releases, including release links, installation guidance, checksum instructions, and implementation-status corrections.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -57,7 +57,7 @@ Status: **ready_with_limitations**. Public documentation now distinguishes skill
 
 ## Test and CI status
 
-Status: **ready_with_limitations**. Unit tests continue on Python 3.10 and 3.11, with Python 3.12 added. A separate release-readiness package-build job builds distributions, runs the audit, checks package contents, and performs clean base/web installation smoke checks without live target network calls.
+Status: **ready_with_limitations**. Base-package compatibility is tested on Python 3.10, 3.11, and 3.12 without optional web dependencies. The optional web control-plane integration suite runs once on Python 3.12 with `.[web]` installed. A separate release-readiness package-build job builds distributions, runs the audit, checks package contents, and performs clean base/web installation smoke checks without live target network calls.
 
 ## Known limitations
 

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -130,6 +130,54 @@ class ReleaseReadinessTests(unittest.TestCase):
         self.assertEqual(package_version(), '0.2.0')
 
 
+    def test_lint_workflow_separates_core_and_web_tests(self):
+        import yaml
+        workflow = (ROOT/'.github/workflows/lint.yml').read_text()
+        parsed = yaml.safe_load(workflow)
+        jobs = parsed['jobs']
+        self.assertIn('python-core-tests', jobs)
+        self.assertIn('web-control-tests', jobs)
+        self.assertIn('release-readiness', jobs)
+        self.assertNotIn('python-cli-tests', jobs)
+
+        for job in jobs.values():
+            self.assertNotIn('continue-on-error', job)
+
+        core = jobs['python-core-tests']
+        self.assertEqual(core['name'], 'Python core tests (${{ matrix.python-version }})')
+        self.assertFalse(core['strategy']['fail-fast'])
+        self.assertEqual(core['strategy']['matrix']['python-version'], ['3.10', '3.11', '3.12'])
+        core_steps = '\n'.join(str(step.get('run', '')) for step in core['steps'])
+        self.assertIn('python -m pip install -e .', core_steps)
+        self.assertNotIn('.[web]', core_steps)
+        self.assertIn('python -m compileall outrider tests mcp-server tools', core_steps)
+        self.assertIn('python -m unittest discover -s tests -p "test_*.py"', core_steps)
+
+        web = jobs['web-control-tests']
+        self.assertEqual(web['name'], 'Web control-plane tests (3.12)')
+        setup = next(step for step in web['steps'] if step.get('uses') == 'actions/setup-python@v5')
+        self.assertEqual(setup['with']['python-version'], '3.12')
+        web_steps = '\n'.join(str(step.get('run', '')) for step in web['steps'])
+        self.assertIn('python -m pip install -e ".[web]"', web_steps)
+        self.assertIn('python -c "import fastapi, httpx, uvicorn"', web_steps)
+        self.assertIn('python -m unittest tests.test_web_view tests.test_web_app', web_steps)
+        self.assertIn('python -m unittest discover -s tests -p "test_*.py"', web_steps)
+
+        release = jobs['release-readiness']
+        release_setup = next(step for step in release['steps'] if step.get('uses') == 'actions/setup-python@v5')
+        self.assertEqual(release_setup['with']['python-version'], '3.12')
+        all_versions = set()
+        for job in jobs.values():
+            matrix = job.get('strategy', {}).get('matrix', {})
+            all_versions.update(matrix.get('python-version', []))
+            for step in job.get('steps', []):
+                if step.get('uses') == 'actions/setup-python@v5':
+                    version = step.get('with', {}).get('python-version')
+                    if isinstance(version, str) and version.startswith('3.'):
+                        all_versions.add(version)
+        self.assertTrue({'3.10', '3.11', '3.12'}.issubset(all_versions))
+
+
     def test_release_notes_changelog_and_workflow(self):
         changelog=(ROOT/'CHANGELOG.md').read_text()
         self.assertIn('## [Unreleased]', changelog)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -39,6 +39,41 @@ def populate(run):
 class WebAppTests(unittest.TestCase):
     def client(self, root, token='tok'): return TestClient(create_app(root, control_token=token))
 
+
+    def test_focused_control_plane_smoke_transition(self):
+        with tempfile.TemporaryDirectory() as td:
+            runs_root = Path(td) / 'runs'
+            runs_root.mkdir()
+            run = make_run(runs_root)
+            rid = load_manifest(run).run_id
+            c = self.client(runs_root, token='fixture')
+
+            health = c.get('/api/health')
+            self.assertEqual(health.status_code, 200)
+            self.assertEqual(health.json()['mode'], 'limited-control')
+            self.assertEqual(c.get('/api/session').status_code, 200)
+            self.assertEqual(c.get('/').status_code, 200)
+            self.assertEqual(c.get('/static/app.css').status_code, 200)
+            self.assertEqual(c.get('/static/app.js').status_code, 200)
+
+            body = {
+                'expected_state': 'initialized',
+                'new_state': 'scoped',
+                'actor': 'authorized-operator',
+                'reason': None,
+            }
+            self.assertEqual(c.post(f'/api/runs/{rid}/state/transition', json=body).status_code, 403)
+            ok = c.post(
+                f'/api/runs/{rid}/state/transition',
+                json=body,
+                headers={'X-Outrider-Control-Token': 'fixture'},
+            )
+            self.assertEqual(ok.status_code, 200, ok.text)
+            self.assertEqual(ok.json()['state']['current_state'], 'scoped')
+            refreshed = c.get(f'/api/runs/{rid}/state')
+            self.assertEqual(refreshed.status_code, 200)
+            self.assertEqual(refreshed.json()['current_state'], 'scoped')
+
     def test_health_runs_details_headers_and_static_ui(self):
         with tempfile.TemporaryDirectory() as td:
             c=self.client(td)

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -85,7 +85,7 @@ class Audit:
         schemas={p.name: json.loads(p.read_text()).get('properties',{}).get('schema_version',{}).get('const') for p in (self.root/'contracts').glob('*.schema.json')}
         return {'python_package':py['project']['version'],'claude_plugin':plugin['version'],'skills':skills,'schemas':schemas,'manifest_schema':1,'state_event_schema':1,'evidence_schema':1,'approval_schema':1,'finding_schema':schemas.get('finding-v1.schema.json')}
     def run(self):
-        self.check_required_files(); self.check_parse(); self.check_versions(); self.check_skills(); self.check_schemas(); self.check_package_data(); self.check_static(); self.check_adrs(); self.check_artifacts(); self.check_security_patterns(); self.check_docs_versions(); self.check_changelog(); self.check_release_workflow(); self.check_mcp(); return self
+        self.check_required_files(); self.check_parse(); self.check_versions(); self.check_skills(); self.check_schemas(); self.check_package_data(); self.check_static(); self.check_adrs(); self.check_artifacts(); self.check_security_patterns(); self.check_docs_versions(); self.check_changelog(); self.check_lint_workflow(); self.check_release_workflow(); self.check_mcp(); return self
 
     def check_versions(self):
         versions = self.versions()
@@ -249,6 +249,39 @@ class Audit:
             self.ok('unreleased changelog cleanup','released entries are not duplicated under Unreleased')
         else:
             self.fail('unreleased changelog cleanup','released entries remain under Unreleased')
+
+
+    def check_lint_workflow(self):
+        if self.is_bundle_root():
+            self.ok('lint workflow exclusion','release bundle intentionally excludes .github workflow files')
+            return
+        path=self.root/'.github/workflows/lint.yml'
+        text=path.read_text(errors='ignore') if path.exists() else ''
+        try:
+            import yaml
+            jobs=yaml.safe_load(text)['jobs']
+            core=jobs['python-core-tests']; web=jobs['web-control-tests']; release=jobs['release-readiness']
+            versions=core['strategy']['matrix']['python-version']
+            core_runs='\n'.join(str(step.get('run','')) for step in core.get('steps',[]))
+            web_runs='\n'.join(str(step.get('run','')) for step in web.get('steps',[]))
+            web_setup=next(step for step in web.get('steps',[]) if step.get('uses') == 'actions/setup-python@v5')
+            release_setup=next(step for step in release.get('steps',[]) if step.get('uses') == 'actions/setup-python@v5')
+            no_continue=all('continue-on-error' not in job for job in jobs.values())
+        except Exception as e:
+            self.fail('lint workflow test structure','workflow does not parse with expected jobs: '+str(e)); return
+        problems=[]
+        if versions != ['3.10','3.11','3.12']: problems.append('core matrix versions')
+        if 'python -m pip install -e .' not in core_runs or '.[web]' in core_runs: problems.append('core base install boundary')
+        if 'python -m unittest discover -s tests -p "test_*.py"' not in core_runs: problems.append('core unittest discovery')
+        if web_setup.get('with',{}).get('python-version') != '3.12': problems.append('web Python 3.12')
+        if 'python -m pip install -e ".[web]"' not in web_runs: problems.append('web extra install')
+        if 'python -c "import fastapi, httpx, uvicorn"' not in web_runs: problems.append('web dependency import check')
+        if 'python -m unittest tests.test_web_view tests.test_web_app' not in web_runs: problems.append('focused web tests')
+        if 'python -m unittest discover -s tests -p "test_*.py"' not in web_runs: problems.append('web full discovery')
+        if release_setup.get('with',{}).get('python-version') != '3.12': problems.append('release-readiness Python 3.12')
+        if not no_continue: problems.append('continue-on-error forbidden')
+        if problems: self.fail('lint workflow test structure','missing or invalid '+', '.join(problems))
+        else: self.ok('lint workflow test structure','base matrix, dedicated web job, and release-readiness job are configured')
 
     def check_release_workflow(self):
         if self.is_bundle_root():

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -257,29 +257,31 @@ class Audit:
             return
         path=self.root/'.github/workflows/lint.yml'
         text=path.read_text(errors='ignore') if path.exists() else ''
-        try:
-            import yaml
-            jobs=yaml.safe_load(text)['jobs']
-            core=jobs['python-core-tests']; web=jobs['web-control-tests']; release=jobs['release-readiness']
-            versions=core['strategy']['matrix']['python-version']
-            core_runs='\n'.join(str(step.get('run','')) for step in core.get('steps',[]))
-            web_runs='\n'.join(str(step.get('run','')) for step in web.get('steps',[]))
-            web_setup=next(step for step in web.get('steps',[]) if step.get('uses') == 'actions/setup-python@v5')
-            release_setup=next(step for step in release.get('steps',[]) if step.get('uses') == 'actions/setup-python@v5')
-            no_continue=all('continue-on-error' not in job for job in jobs.values())
-        except Exception as e:
-            self.fail('lint workflow test structure','workflow does not parse with expected jobs: '+str(e)); return
         problems=[]
-        if versions != ['3.10','3.11','3.12']: problems.append('core matrix versions')
-        if 'python -m pip install -e .' not in core_runs or '.[web]' in core_runs: problems.append('core base install boundary')
-        if 'python -m unittest discover -s tests -p "test_*.py"' not in core_runs: problems.append('core unittest discovery')
-        if web_setup.get('with',{}).get('python-version') != '3.12': problems.append('web Python 3.12')
-        if 'python -m pip install -e ".[web]"' not in web_runs: problems.append('web extra install')
-        if 'python -c "import fastapi, httpx, uvicorn"' not in web_runs: problems.append('web dependency import check')
-        if 'python -m unittest tests.test_web_view tests.test_web_app' not in web_runs: problems.append('focused web tests')
-        if 'python -m unittest discover -s tests -p "test_*.py"' not in web_runs: problems.append('web full discovery')
-        if release_setup.get('with',{}).get('python-version') != '3.12': problems.append('release-readiness Python 3.12')
-        if not no_continue: problems.append('continue-on-error forbidden')
+        try:
+            core_start=text.index('  python-core-tests:')
+            web_start=text.index('  web-control-tests:')
+            release_start=text.index('  release-readiness:')
+            core=text[core_start:web_start]
+            web=text[web_start:release_start]
+            release=text[release_start:]
+        except ValueError:
+            self.fail('lint workflow test structure','missing python-core-tests, web-control-tests, or release-readiness job')
+            return
+        if 'python-cli-tests:' in text: problems.append('old python-cli-tests job remains')
+        if 'continue-on-error' in text: problems.append('continue-on-error forbidden')
+        if not re.search(r'python-version:\s*\n\s*- [\'\"]?3\.10[\'\"]?\s*\n\s*- [\'\"]?3\.11[\'\"]?\s*\n\s*- [\'\"]?3\.12[\'\"]?', core): problems.append('core matrix versions')
+        if 'fail-fast: false' not in core: problems.append('core fail-fast false')
+        if 'python -m pip install -e .' not in core or '.[web]' in core: problems.append('core base install boundary')
+        if 'python -m compileall outrider tests mcp-server tools' not in core: problems.append('core compile command')
+        if 'python -m unittest discover -s tests -p "test_*.py"' not in core: problems.append('core unittest discovery')
+        if not re.search(r'python-version:\s*[\'\"]?3\.12[\'\"]?', web): problems.append('web Python 3.12')
+        if 'python -m pip install -e ".[web]"' not in web: problems.append('web extra install')
+        if 'python -c "import fastapi, httpx, uvicorn"' not in web: problems.append('web dependency import check')
+        if 'python -m compileall outrider tests tools' not in web: problems.append('web compile command')
+        if 'python -m unittest tests.test_web_view tests.test_web_app' not in web: problems.append('focused web tests')
+        if 'python -m unittest discover -s tests -p "test_*.py"' not in web: problems.append('web full discovery')
+        if not re.search(r'python-version:\s*[\'\"]?3\.12[\'\"]?', release): problems.append('release-readiness Python 3.12')
         if problems: self.fail('lint workflow test structure','missing or invalid '+', '.join(problems))
         else: self.ok('lint workflow test structure','base matrix, dedicated web job, and release-readiness job are configured')
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated web-test failures by running optional web integration tests once on a single Python version instead of repeating them across the Python matrix. 
- Preserve full Python compatibility coverage for the base package on all supported interpreters (`3.10`–`3.12`) while keeping web extras optional. 
- Keep release package build and clean-install smoke checks independent and continue to verify packaged web assets and guarded state-transition behavior.

### Description

- Replace the existing multi-version job with a `python-core-tests` matrix that runs on `3.10`, `3.11`, and `3.12`, installs the base package only using `python -m pip install -e .`, compiles sources, and runs `python -m unittest discover -s tests -p "test_*.py"`.
- Add a `web-control-tests` job that runs on `3.12`, installs the web extra with `python -m pip install -e ".[web]"`, verifies optional imports via `python -c "import fastapi, httpx, uvicorn"`, runs focused web tests `python -m unittest tests.test_web_view tests.test_web_app`, and then runs full discovery once with web dependencies.
- Update release-candidate/release-readiness web-smoke checks to assert `mode == "limited-control"` and to verify `/api/session` and packaged static assets without launching a live server.
- Add a focused FastAPI/TestClient smoke test in `tests/test_web_app.py` that creates a temporary runs root, builds a run with helpers, injects a deterministic control token, verifies health/session/static endpoints, asserts tokenless mutation returns `403`, performs an `initialized -> scoped` transition with the token, and verifies refreshed state is `scoped`.
- Add workflow-structure regression assertions in `tests/test_release_readiness.py` and a `check_lint_workflow` audit in `tools/release_audit.py` to validate matrix versions, install boundaries, presence of `web-control-tests`, absence of `continue-on-error`, and that the core job does not install `.[web]`.
- Update `docs/release-readiness.md` and `CHANGELOG.md` (Unreleased → Changed) to document the CI split and preserve all runtime behavior and package/version/schema metadata unchanged.

### Testing

- Ran `python tools/release_audit.py` and `python tools/release_audit.py --json` which both completed with overall status `ready` / `ready_with_limitations` as reported by the audit tool. 
- Ran `python -m unittest discover -s tests -p "test_*.py"` which executed `99` tests with `7` skipped and returned `OK (skipped=7)`.
- Ran focused `python -m unittest tests.test_web_app tests.test_release_readiness` which ran `20` tests with `7` skipped and returned `OK (skipped=7)`.
- Ran `python -m compileall outrider tests mcp-server tools` which completed successfully and verified byte-compilation.
- Validated JSON artifacts with `python -m json.tool` on `.claude-plugin/plugin.json` and the three contract schema files which succeeded.
- Executed YAML-based workflow assertions (the `yaml.safe_load` checks used by `tests/test_release_readiness.py`) which verified that `python-core-tests` matrix equals `['3.10','3.11','3.12']`, that the core job uses `python -m pip install -e .`, that `.github` contains `web-control-tests` and `release-readiness`, and that the web job installs `.[web]` and imports `fastapi`, `httpx`, and `uvicorn` as expected.
- Environment/tooling notes: `npx --yes markdownlint-cli2` failed to fetch the package due to an external `npm` registry `403 Forbidden` in this environment, and `python -m build` / `python -m twine check` could not be completed locally because `build`/`twine` installation was blocked by package-index access restrictions; these are environment limitations and do not affect the CI workflow changes.
- Audited base commit before edits: `c7ade19d9a376652cc9c4a33d4c9e099e145841d` and final local commit SHA: `e90bab2c6a18f5d0d0f7cd37349812b8311f8498`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54a01f5e0483308882aec8c73501d2)