### PR TITLE
feat(web): surface unsafe contract-directory errors in Contracts view and add regression test

### DIFF
--- a/outrider/web_view.py
+++ b/outrider/web_view.py
@@ -226,7 +226,13 @@ def validation_context(run_dir: str | Path) -> dict[str, Any]:
     current_state = None
     try: current_state = load_state(run_dir).current_state
     except Exception: pass
-    return {"current_state": current_state, "contract_revision": contract_revision(run_dir), "scope_revision": scope_revision(run_dir), "approval_revision": approval_revision(run_dir), "evidence_revision": evidence_revision(run_dir)}
+    revision_error = None
+    try:
+        revision = contract_revision(run_dir)
+    except SkillContractValidationError as exc:
+        revision = None
+        revision_error = _clean(exc)
+    return {"current_state": current_state, "contract_revision": revision, "contract_revision_error": revision_error, "scope_revision": scope_revision(run_dir), "approval_revision": approval_revision(run_dir), "evidence_revision": evidence_revision(run_dir)}
 
 
 def _evidence_options(run_dir: Path) -> list[dict[str, Any]]:
@@ -270,6 +276,8 @@ def contract_view(run_dir: str | Path) -> dict[str, Any]:
     invalid_req=sum(1 for i in inventory["requests"] if i.get("error"))
     invalid_res=sum(1 for i in inventory["results"] if i.get("error"))
     ctx=validation_context(run)
+    if ctx.get("contract_revision_error"):
+        errors.append(ViewError("contracts", ctx["contract_revision_error"]))
     return {"valid": not errors, "current_state": ctx["current_state"], "contract_revision": ctx["contract_revision"], "validation_context": ctx, "known_skills": list(list_known_skills()), "request_action_types": request_action_catalog(), "evidence_options": _evidence_options(run), "request_count": len(requests), "result_count": len(results), "invalid_request_count": invalid_req, "invalid_result_count": invalid_res, "requests": requests, "results": results, "errors": [e.to_dict() for e in errors], "notice": "Point-in-time contract summaries only. Request creation does not execute skills; result validation does not promote finding_candidate claims."}
 
 

--- a/tests/test_web_view.py
+++ b/tests/test_web_view.py
@@ -80,6 +80,20 @@ class WebViewTests(unittest.TestCase):
             (run/ev.path).write_text('changed', encoding='utf-8')
             self.assertNotEqual(web_view.view_for_run_id(td,rid,'integrity')['evidence_verification_counts']['mismatch'],0)
 
+    def test_contract_view_reports_unsafe_contract_directory_without_crashing(self):
+        with tempfile.TemporaryDirectory() as td:
+            run=make_run(td); rid=load_manifest(run).run_id
+            target=Path(td)/'external-requests'; target.mkdir()
+            requests=run/'contracts'/'requests'
+            requests.rmdir()
+            requests.symlink_to(target, target_is_directory=True)
+            data=web_view.view_for_run_id(td,rid,'contracts')
+            self.assertIsInstance(data, dict)
+            self.assertFalse(data['valid'])
+            self.assertIsNone(data['contract_revision'])
+            self.assertTrue(any('contracts/requests is a symbolic link' in e['message'] for e in data['errors']))
+            self.assertNotIn(td, serial(data))
+
     def test_symlink_root_rejected_and_no_write_functions_or_network(self):
         with tempfile.TemporaryDirectory() as td:
             root=Path(td); runs=root/'runs'; runs.mkdir(); link=root/'runs-link'; link.symlink_to(runs, target_is_directory=True)


### PR DESCRIPTION
### Motivation
- The Contracts dashboard could crash when contract directories were unsafe (for example, symlinked); this change ensures the projection surfaces a sanitized contract-revision error instead of raising.

### Description
- Catch `SkillContractValidationError` when computing `contract_revision` in `validation_context` and expose `contract_revision_error` while preserving other context fields in `outrider/web_view.py`.
- Append a sanitized `ViewError` to the Contracts view when a contract-revision error is present so the UI shows the issue instead of failing during projection in `outrider/web_view.py`.
- Add a regression test `test_contract_view_reports_unsafe_contract_directory_without_crashing` in `tests/test_web_view.py` that creates a symlinked `contracts/requests` directory and asserts the Contracts view is returned, marked invalid, reports a `contract_revision` of `null`, includes a sanitized error message, and does not leak absolute paths.

### Testing
- Ran focused unit tests `tests.test_web_view`, `tests.test_skill_contract`, and `tests.test_web_app` and they passed (focused run: all tests OK for the modified areas).
- Ran full test suite via `python -m unittest discover -s tests -p "test_*.py"` and all tests passed (suite run completed with tests passing and expected skips).
- Executed repository quality checks: `tools/release_audit.py` (including `--json`), JSON schema validation, `markdownlint-cli2` on docs, package build, and `twine check`, all of which completed successfully.
- Verified no new network/LLM/MCP/skill execution behavior was introduced and the change is limited to projection error handling and the added regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56897a5a188330b0faf9b928a0acce)