### PR TITLE
Treat release audit warnings as non-fatal

### DIFF
--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -52,7 +52,7 @@ class ReleaseReadinessTests(unittest.TestCase):
             (root/'fixture.txt').write_text('token = "' + 'abcdefghijklmnopqrstuvwxyz' + '"')
             buf=io.StringIO()
             with contextlib.redirect_stdout(buf): code=release_audit.main(['--root',str(root),'--json'])
-            self.assertEqual(code, 1)
+            self.assertEqual(code, 0)
             (root/'outrider/skill_catalog.json').write_text('{"schema_version":1,"skills":[]}')
             buf=io.StringIO()
             with contextlib.redirect_stdout(buf): code=release_audit.main(['--root',str(root),'--json'])

--- a/tools/release_audit.py
+++ b/tools/release_audit.py
@@ -365,5 +365,5 @@ def main(argv=None):
     else:
         for c in audit.checks: print(f'{c.status}: {c.name} - {c.detail}')
         print(f'Overall status: {status}')
-    return 2 if status=='blocked' else 1 if status=='ready_with_limitations' else 0
+    return 2 if status=='blocked' else 0
 if __name__=='__main__': raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- The release audit currently returns a non-zero exit code for runs that only produce warnings (`ready_with_limitations`), which disrupts CI jobs that should only fail on hard `blocked` conditions.
- Tests reflected the prior behavior by expecting a non-zero exit for warning-only runs and needed to be updated to the revised exit semantics.

### Description

- Modified `tools/release_audit.py` `main` return logic so that only `blocked` audits return a non-zero exit: changed to `return 2 if status=='blocked' else 0` and preserved the human/JSON output of the `overall_status` field. 
- Updated `tests/test_release_readiness.py` to expect a zero exit (`self.assertEqual(code, 0)`) for a warning-only `ready_with_limitations` audit while keeping the fatal expectation (`2`) for true failures. 
- The change preserves all existing status reporting and JSON payload contents produced by `release_audit` while making warning-only runs non-fatal for CI.

### Testing

- Ran the targeted unit test `python -m unittest tests.test_release_readiness.ReleaseReadinessTests.test_warning_and_failure_exit_codes`, which passed. 
- Ran the full suite `python -m unittest tests.test_release_readiness`, which completed successfully (`OK`, with one skip). 
- Executed the audit script directly with `python tools/release_audit.py`, which produced the expected human-readable checks and returned exit code `0` for a warning-only/ready run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5711bd9668833091b3e7de08bbab93)