### PR TITLE
One-command bootstrap + Docker portal; harden release-readiness fixture

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.venv
+venv
+runs
+dist
+build
+*.egg-info
+**/__pycache__
+**/*.pyc
+.pytest_cache
+node_modules

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: ludeeus/action-shellcheck@master
         with:
           scandir: .
-          additional_files: install.sh uninstall.sh
+          additional_files: install.sh uninstall.sh bootstrap.sh
 
   python-core-tests:
     name: Python core tests (${{ matrix.python-version }})
@@ -236,3 +236,23 @@ jobs:
               ''')
               subprocess.check_call([py, '-c', smoke])
           PY
+
+  docker-portal:
+    name: Docker web portal build + smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t outrider-recon .
+      - name: Smoke test the loopback portal
+        run: |
+          docker run -d --name outrider --network host outrider-recon
+          ok=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8765/api/health >/dev/null 2>&1; then ok=1; break; fi
+            sleep 1
+          done
+          docker logs outrider || true
+          docker rm -f outrider >/dev/null 2>&1 || true
+          if [ "$ok" != "1" ]; then echo "portal did not become healthy"; exit 1; fi
+          echo "OK: portal served /api/health over loopback"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ breach-data/
 stealer-logs/
 */OWASP_
 
+# Python virtual environments (repo-local venvs from `pip install -e .`)
+.venv/
+venv/
+
 # API keys / config that shouldn't ship
 .env
 .env.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added an independent advisory verifier (`outrider verify candidates`) that attempts to falsify each finding candidate against its cited evidence and current scope, recording `supported`, `refuted`, or `insufficient_evidence` verdicts under `contracts/verification/`. Verdicts never promote, never delete, and never gate promotion eligibility. (ADR 0018)
 - Added a deterministic benchmark harness (`outrider benchmark run|analyze-misses`) that drives the loop over a synthetic ground-truth corpus with a stub executor and scores schema conformance, discovered-candidate precision/recall, and finding-candidate coverage. Metrics are reproducible with no model or network; a shipped corpus and the `ground-truth-v1` and `verification-v1` contracts back it. (ADR 0019)
 - Added `tests/test_secret_scan.py`, pinning the secret-pattern catalog's exact-length contract in both directions.
+- Added `bootstrap.sh`: one command that creates an isolated virtualenv, installs the package (web extra by default), links the Claude skills from the checkout, and runs the deterministic self-check. Flags: `--no-web`, `--no-skills`, `--help`.
+- Added a `Dockerfile` (+ `.dockerignore`) that serves the loopback-only web portal; reachable on Linux with `docker run --network host`. It deliberately does not bind `0.0.0.0`. CI now builds the image and smoke-tests `/api/health`.
 
 ### Changed
 
@@ -30,6 +32,7 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Restored the functional Advanced Workspace controls alongside web-first onboarding.
 - Removed hard-coded next actions, corrected terminal phase labels, removed hidden static test markers, and corrected malformed architecture wording.
 - Fixed an unhandled `re.error` crash in `h1_reference.py` when `--query` or `--cwe` received an invalid regular expression.
+- Hardened `copy_repo_fixture` in the release-readiness tests to strip `runs/`, `.venv/`, and `venv/` (and added `.venv/`/`venv/` to `.gitignore`). Previously, running `outrider init` or the web portal created a local `runs/` folder that the fixture copied into a `.git`-less audit, tripping `check_artifacts` and failing `test_warning_and_failure_exit_codes` for anyone who had actually used the tool.
 - Fixed the `secret_scan.py` CI smoke test, whose GitHub PAT fixture carried 37 characters instead of 36 and was never asserted on, so `GH_PAT_CLASSIC` silently never matched.
 - Fixed `install.sh` copying helper scripts onto themselves through a symlink while silencing the resulting error, and counting unrelated skills already present in `~/.claude/skills`.
 - Fixed `uninstall.sh` removing skills by hardcoded name, which could delete a user's own skill sharing a generic name; it now removes only symlinks resolving into the install directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Outrider web portal in a container.
+#
+# Build:  docker build -t outrider-recon .
+# Run:    docker run --rm --network host outrider-recon
+#         then open http://127.0.0.1:8765
+#
+# Outrider binds loopback only by design (it refuses non-loopback hosts), so the
+# container shares the host loopback via `--network host` (Linux). We do NOT bind
+# 0.0.0.0 — that would violate Outrider's own security posture and fail its
+# release audit. On macOS/Windows Docker Desktop, `--network host` is limited;
+# prefer the native `./bootstrap.sh` path there.
+#
+# Persist runs across container restarts by mounting a volume:
+#   docker run --rm --network host -v "$PWD/runs:/home/outrider/runs" outrider-recon
+FROM python:3.12-slim
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /src
+COPY . /src
+
+# Non-editable install so the runtime does not depend on the source tree; the
+# packaged skill catalog, schemas, web static assets, and benchmark corpus ship
+# as package data.
+RUN python -m pip install --upgrade pip \
+    && python -m pip install ".[web]" \
+    && useradd --create-home --uid 10001 outrider
+
+USER outrider
+WORKDIR /home/outrider
+EXPOSE 8765
+
+# Loopback-only bind; reach it from the host with `--network host`.
+CMD ["outrider", "--no-browser", "--host", "127.0.0.1", "--port", "8765"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,32 @@ Outrider Recon → ranked leads / technique cards → proxy-assisted testing, ma
 
 ## Quick start
 
-Install the web extra and run `outrider` to start the local browser portal:
+**Fastest path — one command.** From a checkout, `bootstrap.sh` creates an
+isolated virtualenv, installs the package, links the Claude skills, and runs a
+deterministic self-check so you know it works before touching a target:
+
+```bash
+git clone https://github.com/Ap6pack/outrider-recon.git
+cd outrider-recon
+./bootstrap.sh            # add --no-web for a base install, --no-skills to skip skill linking
+source .venv/bin/activate
+outrider                 # start the local browser portal
+```
+
+A healthy self-check ends with `promoted_findings_total: 0` and
+`schema_validity_rate: 1.0`. That is the friction-free way to confirm the
+install; no API keys, targets, or network needed.
+
+**Just want to see it in a browser (Docker, Linux).** Outrider binds loopback
+only by design, so share the host loopback with `--network host`:
+
+```bash
+docker build -t outrider-recon .
+docker run --rm --network host outrider-recon
+# then open http://127.0.0.1:8765
+```
+
+**Manual path.** Install the web extra and run `outrider`:
 
 ```bash
 python -m pip install -e ".[web]"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# outrider-recon one-command setup + self-check.
+#
+# Run from a checkout of the repo:
+#   ./bootstrap.sh                # venv + web extra + link skills + self-check
+#   ./bootstrap.sh --no-web       # base install only (no FastAPI/uvicorn)
+#   ./bootstrap.sh --no-skills    # skip linking Claude skills into ~/.claude/skills
+#   ./bootstrap.sh --help
+#
+# It creates an isolated virtualenv in ./.venv, installs the Python package,
+# symlinks the 11 Claude skills from THIS checkout into ~/.claude/skills, and
+# runs the deterministic benchmark self-check (no model, no network) so you know
+# the install works before you touch a real target.
+
+WEB=1
+SKILLS=1
+VENV_DIR=".venv"
+SKILLS_DIR="${HOME}/.claude/skills"
+
+usage() {
+  cat <<'USAGE'
+outrider-recon one-command setup + self-check. Run from a repo checkout.
+
+Usage: ./bootstrap.sh [options]
+  (no options)   virtualenv + web extra + link skills + self-check
+  --no-web       base install only (no FastAPI/uvicorn)
+  --no-skills    skip linking Claude skills into ~/.claude/skills
+  -h, --help     show this help
+
+Creates an isolated virtualenv in ./.venv, installs the package, symlinks the
+Claude skills from THIS checkout into ~/.claude/skills, and runs the
+deterministic benchmark self-check (no model, no network).
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-web) WEB=0 ;;
+    --no-skills) SKILLS=0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: unknown option: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+if [ ! -f "pyproject.toml" ]; then
+  echo "Error: run bootstrap.sh from inside the outrider-recon checkout." >&2
+  exit 1
+fi
+
+# 1. Find a Python interpreter >= 3.10.
+find_python() {
+  local candidate
+  for candidate in python3.13 python3.12 python3.11 python3.10 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 10) else 1)' 2>/dev/null; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+if ! PY="$(find_python)"; then
+  echo "Error: Python 3.10+ is required but was not found on PATH." >&2
+  exit 1
+fi
+echo "Using $("$PY" --version 2>&1) at $(command -v "$PY")"
+
+# 2. Create the isolated virtualenv.
+if [ ! -d "$VENV_DIR" ]; then
+  echo "Creating virtualenv in $VENV_DIR ..."
+  "$PY" -m venv "$VENV_DIR"
+fi
+VPY="$VENV_DIR/bin/python"
+if [ ! -x "$VPY" ]; then
+  VPY="$VENV_DIR/Scripts/python.exe"  # Windows layout fallback
+fi
+if [ ! -x "$VPY" ]; then
+  echo "Error: virtualenv Python not found under $VENV_DIR." >&2
+  exit 1
+fi
+
+# 3. Install the package.
+"$VPY" -m pip install --quiet --upgrade pip
+if [ "$WEB" -eq 1 ]; then
+  echo "Installing outrider-recon with the web extra ..."
+  "$VPY" -m pip install --quiet -e ".[web]"
+else
+  echo "Installing outrider-recon (base) ..."
+  "$VPY" -m pip install --quiet -e .
+fi
+
+# 4. Link the Claude skills from THIS checkout (no re-clone).
+if [ "$SKILLS" -eq 1 ]; then
+  mkdir -p "$SKILLS_DIR"
+  linked=0
+  for skill_dir in "$REPO_DIR"/skills/*/; do
+    [ -f "${skill_dir}SKILL.md" ] || continue
+    skill_dir="${skill_dir%/}"
+    target="$SKILLS_DIR/$(basename "$skill_dir")"
+    if [ -L "$target" ] || [ -e "$target" ]; then
+      rm -rf "$target"
+    fi
+    ln -sfn "$skill_dir" "$target"
+    linked=$((linked + 1))
+  done
+  echo "Linked $linked Claude skills into $SKILLS_DIR"
+fi
+
+# 5. Deterministic self-check: no model, no network.
+echo ""
+echo "Running self-check (deterministic benchmark) ..."
+"$VPY" -m outrider benchmark run --tally-only
+
+# 6. Next steps.
+cat <<EOF
+
+Setup complete. Activate the environment with:
+  source $VENV_DIR/bin/activate
+
+Then pick how you want to use Outrider:
+  * Web portal (human UI):     outrider
+  * Governed-loop status:      outrider orchestrate status runs/<target>
+  * Full test suite:           python -m unittest discover -s tests -p "test_*.py"
+  * Claude skills:             start a Claude Code session and ask for an
+                               authorized external recon plan.
+
+Use Outrider only for assets you own or are authorized to assess.
+EOF

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,38 @@
 # Outrider quick start
 
-Outrider is now web-first for human use. Install the web extra, start the local
+## One command (recommended)
+
+From a checkout, `bootstrap.sh` sets everything up and self-checks it:
+
+```bash
+git clone https://github.com/Ap6pack/outrider-recon.git
+cd outrider-recon
+./bootstrap.sh
+source .venv/bin/activate
+outrider
+```
+
+It creates an isolated `./.venv`, installs the package (web extra by default),
+links the Claude skills from this checkout into `~/.claude/skills`, and runs the
+deterministic benchmark self-check (no model, no network). A healthy run ends
+with `promoted_findings_total: 0` and `schema_validity_rate: 1.0`. Flags:
+`--no-web` (base install), `--no-skills` (skip skill linking), `--help`.
+
+## Docker (Linux, browser only)
+
+Outrider binds loopback only, so share the host loopback with `--network host`:
+
+```bash
+docker build -t outrider-recon .
+docker run --rm --network host outrider-recon   # open http://127.0.0.1:8765
+```
+
+We deliberately do not bind `0.0.0.0`. On macOS/Windows Docker Desktop
+`--network host` is limited; prefer `./bootstrap.sh` there.
+
+## Manual
+
+Outrider is web-first for human use. Install the web extra, start the local
 portal, and complete the browser wizard before reviewing scope.
 
 ```bash

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -20,7 +20,12 @@ import release_audit
 
 def copy_repo_fixture(root: Path) -> None:
     subprocess.check_call(['cp','-a',str(ROOT)+'/.',str(root)])
-    for pattern in ['__pycache__', '.pytest_cache', 'build', 'dist', '*.egg-info']:
+    # Strip local, git-ignored working-directory artifacts so the fixture reflects
+    # a clean checkout. Without .git the audit rglob-scans everything, so a `runs/`
+    # folder (created the moment someone runs `outrider init` or the web portal) or
+    # a repo-local virtualenv would otherwise trip check_artifacts and mask the
+    # WARN-vs-FAIL behavior this test asserts.
+    for pattern in ['__pycache__', '.pytest_cache', 'build', 'dist', '*.egg-info', 'runs', '.venv', 'venv']:
         for path in root.rglob(pattern):
             if path.exists():
                 if path.is_dir():


### PR DESCRIPTION
# Pull Request

## Description

Onboarding was three separate manual steps (pip install, skills install, and knowing *which* "test" confirms it works), and the release-readiness test failed for anyone who had actually run the tool. This makes first-run **one command**, adds a **Docker** path, and fixes the fixture blind spot behind that failure.

**`bootstrap.sh` — one command from a checkout.** Creates an isolated `./.venv`, installs the package (web extra by default; `--no-web` for base), links the 11 Claude skills from *this* checkout into `~/.claude/skills` (`--no-skills` to skip), and runs the deterministic benchmark self-check so success is obvious before touching a target. A healthy run ends with `promoted_findings_total: 0` / `schema_validity_rate: 1.0`. shellcheck-clean and added to the CI shellcheck job.

**`Dockerfile` + `.dockerignore` — browser in one command (Linux).** Serves the loopback-only web portal from a container, reachable with `docker run --network host`. It deliberately does **not** bind `0.0.0.0`, preserving Outrider's loopback-only security posture (which its own release audit enforces); macOS/Windows should prefer `bootstrap.sh`. A new `docker-portal` CI job builds the image and smoke-tests `/api/health`.

**Fix the failing `test_warning_and_failure_exit_codes` at the root, not with a band-aid.** `copy_repo_fixture` copied the whole working directory with `cp -a`, stripped `.git`, then let the audit rglob-scan everything — but it did not strip `runs/` or `.venv/`. Running `outrider init` or the web portal creates `./runs/…/manifest.json`, which the fixture dragged into the `.git`-less audit, tripping `check_artifacts` → exit 2 → `2 != 0`. The fixture now strips `runs/`, `.venv/`, `venv/`, and `.gitignore` ignores `.venv/`/`venv/`. Verified the test passes with both `./runs` and a `.venv` present.

## Type of change

- [x] New capability (non-breaking) — installer + Docker
- [x] Bug fix (non-breaking) — release-readiness fixture robustness
- [x] Documentation update
- [ ] Renumbering / restructuring

## Why (the ask behind it)

"Why can't onboarding be one command / one click — it's 2026." Fair. This is the low-risk, high-leverage slice: a single `./bootstrap.sh` that installs *and* self-verifies, plus a Docker recipe for a pure browser experience — without weakening the loopback-only posture the project deliberately enforces.

## Affected components

- New: `bootstrap.sh`, `Dockerfile`, `.dockerignore`.
- CI: `.github/workflows/lint.yml` — `bootstrap.sh` added to shellcheck; new `docker-portal` build + `/api/health` smoke job.
- Fix: `tests/test_release_readiness.py` (`copy_repo_fixture`), `.gitignore`.
- Docs: `README.md` quick start, `docs/quick-start.md`, `CHANGELOG.md [Unreleased]`.

## Verification (local)

- `python -m unittest discover -s tests -p "test_*.py"` → **165 pass** (16 skipped), including with a `./runs` folder and a `.venv` present — the exact scenario that failed before.
- `python -m unittest tests.test_release_readiness` → passes (validates the lint.yml structure with the new job and the hardened fixture).
- `python tools/release_audit.py` → `ready`.
- `shellcheck bootstrap.sh install.sh uninstall.sh` → clean.
- `markdownlint-cli2` → clean across 83 files.
- End-to-end `./bootstrap.sh --no-web --no-skills` → venv created, package installed, self-check `0 promoted / 1.0`.

## Notes / honest caveats

- **The Docker image was not built in the authoring environment** (no Docker daemon here). That is exactly why the PR adds the `docker-portal` CI job — it builds the image and curls `/api/health` on a Linux runner, so the Docker path is validated on this PR rather than asserted. If that job goes red I'll fix it on this branch.
- **No release-version bump** (same reason as the prior PR: the audit + readiness tests pin `0.3.0`/`3.1.0`). Onboarding tooling ships under `[Unreleased]`.
- Based off current `main` (includes the merged cleanup and agentic-loop work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LRwR6gLQWA3nZQbY7iCXj

---
_Generated by [Claude Code](https://claude.ai/code/session_014LRwR6gLQWA3nZQbY7iCXj)_