### PR TITLE
docs(usage): use spaced table delimiters in scope-syntax table

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,7 +184,7 @@ default launcher).
 evaluated first, so an exclusion wins over any inclusion.
 
 | Rule | Matches |
-|---|---|
+| --- | --- |
 | `example.com` | that exact host |
 | `*.example.com` | any subdomain (not the apex — list `example.com` too if you need it) |
 | `192.0.2.10`, `198.51.100.0/24`, `2001:db8::/32` | that IP or network |


### PR DESCRIPTION
## Description

Fixes the one `markdownlint` MD060 (table-column-style) violation in the repo: the scope-rule table added in `docs/usage.md` used a compact `|---|---|` delimiter row while its header and data rows are spaced, and every other table in the repo uses spaced delimiters. This aligns it with the repo convention so the **Markdown lint** CI job stays green.

Verified with `markdownlint-cli2 --config .markdownlint.json "**/*.md" "!node_modules/**"` → **0 issues in 0 files** across all 84 markdown files.

## Type of change

- [x] Documentation update

## Affected skills

- [x] Repo infrastructure only (docs, CI, etc.)

## Checklist

- [x] Doc-only change; no behavior, no code.
- [x] Ran the full-repo markdownlint pass locally — clean.
- [x] My commits follow the format `<type>(<scope>): <subject>`.

## Additional notes

Follow-up polish to PR #43. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LRwR6gLQWA3nZQbY7iCXj

---
_Generated by [Claude Code](https://claude.ai/code/session_014LRwR6gLQWA3nZQbY7iCXj)_